### PR TITLE
tsconfig alias 설정에서 hooks 뒤에 path 가 붙을 수 있도록 설정한다

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,7 @@
       "@template": ["pages/template/"],
       "@pages": ["pages"],
       "@assets/*": ["assets/*"],
-      "@hooks": ["hooks"],
+      "@hooks/*": ["hooks/*"],
       "@mocks/*": ["mocks/*"],
       "@repository/*": ["repository/*"],
       "@routes": ["routes/"],


### PR DESCRIPTION
* `"@hooks": ["hooks"]` 에서 `@hooks/*": ["hooks/*"]` 로변경
  * /*가 붙으면 alias 사용시 뒤에 경로가 더 붙는다는 것을 의미
