### PR TITLE
redux toolkit reducer 정의에 immer를 사용하도록 처리 및 누락된 테스트 코드를 추가한다

### DIFF
--- a/store/authSlice.test.js
+++ b/store/authSlice.test.js
@@ -1,0 +1,35 @@
+import authReducer, {
+  setUser,
+  // TODO: 아래 3가지에 대해 테스트 작성
+  // setLogin,
+  // setUserInfo,
+  // setLogout,
+} from './authSlice';
+
+describe('authReducer에서', () => {
+  context('각 프로퍼티가', () => {
+    it('setUser를 사용해 userId, name, position, department를 수정할 수 있다', () => {
+      const initialState = {
+        userId: '',
+        name: '',
+        position: '',
+        department: '',
+      };
+
+      const state = authReducer(
+        initialState,
+        setUser({
+          userId: 'dummy',
+          name: 'dummy',
+          position: 'dummy',
+          department: 'dummy',
+        }),
+      );
+
+      expect(state.userId).toEqual('dummy');
+      expect(state.name).toEqual('dummy');
+      expect(state.position).toEqual('dummy');
+      expect(state.department).toEqual('dummy');
+    });
+  });
+});

--- a/store/authSlice.ts
+++ b/store/authSlice.ts
@@ -1,26 +1,37 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { postLoginApi, getUserInfo } from '@repository/baseRepository';
 import { NextRouter } from 'next/router';
 import { saveItem, removeItem } from '@utils/storage';
 import { setLoading } from '@store';
 
+interface AuthState {
+  userId: string;
+  name: string;
+  position: string;
+  department: string;
+}
+
+const initialState: AuthState = {
+  userId: '',
+  name: '',
+  position: '',
+  department: '',
+};
+
 const authReducer = createSlice({
   name: 'auth',
-  initialState: {
-    userId: '',
-    name: '',
-    position: '',
-    department: '',
-  },
+  initialState,
   reducers: {
-    setUser(state, { payload: { userId, name, position, department } }) {
-      return {
-        ...state,
-        userId,
-        name,
-        position,
-        department,
-      };
+    setUser(
+      state,
+      {
+        payload: { userId, name, position, department },
+      }: PayloadAction<AuthState>,
+    ) {
+      state.userId = userId;
+      state.name = name;
+      state.position = position;
+      state.department = department;
     },
   },
 });

--- a/store/modalSlice.ts
+++ b/store/modalSlice.ts
@@ -1,32 +1,43 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { MODALS } from '@utils/constants';
+
+interface ModalState {
+  // TODO: 타입 정의
+  [MODALS.ALERT_MODAL]: boolean;
+  content?: string;
+}
+
+const initialState: ModalState = {
+  [MODALS.ALERT_MODAL]: false,
+  content: '',
+};
 
 const modalReducer = createSlice({
   name: 'modal',
-  initialState: {
-    [MODALS.ALERT_MODAL]: false,
-    content: '',
-  },
+  initialState,
   reducers: {
-    displayModal(state, { payload: { modalName, content } }) {
-      return {
-        ...state,
-        [modalName]: true,
-        content: content || '',
-      };
+    displayModal(
+      state,
+      {
+        payload: { modalName, content },
+      }: PayloadAction<{ modalName: string; content: string }>,
+    ) {
+      // TODO: 타입 정의
+      state[modalName] = true;
+      state.content = content;
     },
-    removeModal(state, { payload: { modalName } }) {
-      return {
-        ...state,
-        [modalName]: false,
-        content: '',
-      };
+    removeModal(
+      state,
+      { payload: { modalName } }: PayloadAction<{ modalName: string }>,
+    ) {
+      state[modalName] = false;
+      state.content = '';
     },
-    setContent(state, { payload: { content } }) {
-      return {
-        ...state,
-        content,
-      };
+    setContent(
+      state,
+      { payload: { content } }: PayloadAction<{ content: string }>,
+    ) {
+      state.content = content;
     },
   },
 });

--- a/store/uiSlice.test.js
+++ b/store/uiSlice.test.js
@@ -1,0 +1,20 @@
+import uiSlice, { setLoading } from './uiSlice';
+
+describe('uiSlice에서', () => {
+  context('각 프로퍼티가', () => {
+    it('setLoading를 사용해 isLoading을 수정할 수 있다', () => {
+      const initialState = {
+        isLoading: false,
+      };
+
+      const state = uiSlice(
+        initialState,
+        setLoading({
+          isLoading: false,
+        }),
+      );
+
+      expect(state.isLoading).toEqual(false);
+    });
+  });
+});

--- a/store/uiSlice.ts
+++ b/store/uiSlice.ts
@@ -1,10 +1,16 @@
 import { createSlice } from '@reduxjs/toolkit';
 
+interface UIState {
+  isLoading: boolean;
+}
+
+const initialState: UIState = {
+  isLoading: false,
+};
+
 const uiReducer = createSlice({
   name: 'ui',
-  initialState: {
-    isLoading: false,
-  },
+  initialState,
   reducers: {
     setLoading(state, { payload: { isLoading } }) {
       return {


### PR DESCRIPTION
* redux toolkit reducer 정의에 immer를 사용하도록 처리한다
* authSlice, uiSlice의 테스트코드를 추가한다

## Reference
https://redux-toolkit.js.org/usage/immer-reducers