### PR TITLE
Delete `␍` eslint 에러를 해결한다

### DIFF
--- a/FE/.eslintrc
+++ b/FE/.eslintrc
@@ -2,6 +2,11 @@
   "extends": ["next", "next/core-web-vitals", "prettier"],
   "plugins": ["prettier"],
   "rules": {
-    "prettier/prettier": ["error"]
+    "prettier/prettier": [
+      "error",
+      {
+        "endOfLine": "auto"
+      }
+    ]
   }
 }


### PR DESCRIPTION
Delete `␍` eslint 에러를 해결하기 위한 코드를 추가하였습니다.