### PR TITLE
페이지 맨 하단에 붙는 footer 구성

### DIFF
--- a/FE/components/organisms/Footer/Footer.tsx
+++ b/FE/components/organisms/Footer/Footer.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Text } from '@atoms';
+
+const Wrapper = styled.footer`
+  margin-top: auto;
+  width: 100%;
+  height: 50px;
+  display: flex;
+  ${({ theme: { flexRow } }) => flexRow()};
+  background: #262626;
+  color: #666;
+  font-size: 5em;
+  text-transform: uppercase;
+`;
+
+export default function Footer() {
+  return (
+    <Wrapper>
+      <Text text="copyright 2020 SSAFY 5th" />
+    </Wrapper>
+  );
+}

--- a/FE/components/organisms/Footer/index.ts
+++ b/FE/components/organisms/Footer/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Footer';

--- a/FE/components/organisms/index.ts
+++ b/FE/components/organisms/index.ts
@@ -1,7 +1,15 @@
 import Modal from './Modal';
 import Navbar from './Navbar';
+import Footer from './Footer';
 import LineBackground from './LineBackground';
 import LoginComponent from './LoginComponent';
 import RegisterComponent from './RegisterComponent';
 
-export { Modal, Navbar, LineBackground, LoginComponent, RegisterComponent };
+export {
+  Modal,
+  Navbar,
+  Footer,
+  LineBackground,
+  LoginComponent,
+  RegisterComponent,
+};

--- a/FE/pages/_app.tsx
+++ b/FE/pages/_app.tsx
@@ -1,15 +1,19 @@
 import { Provider } from 'react-redux';
 import { ThemeProvider } from 'styled-components';
-
 import type { AppProps } from 'next/app';
 
-import { Modal, Navbar } from '@organisms';
+import { Modal, Navbar, Footer } from '@organisms';
 import { Spinner } from '@molecules';
 import { MODALS } from '@utils/constants';
+import styled from 'styled-components';
 import GlobalStyle from '@styles/globalStyles';
-
 import store from '@store';
 import theme from '@styles/theme';
+
+const Wrapper = styled.section`
+  margin-top: 100px;
+  margin-bottom: 50px;
+`;
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
@@ -17,9 +21,10 @@ function MyApp({ Component, pageProps }: AppProps) {
       <ThemeProvider theme={theme}>
         <GlobalStyle />
         <Navbar />
-        <section style={{ marginTop: '83px' }}>
+        <Wrapper>
           <Component {...pageProps} />
-        </section>
+        </Wrapper>
+        <Footer />
         <Modal modalName={MODALS.ALERT_MODAL} />
         <Spinner />
       </ThemeProvider>

--- a/FE/pages/_app.tsx
+++ b/FE/pages/_app.tsx
@@ -11,8 +11,8 @@ import store from '@store';
 import theme from '@styles/theme';
 
 const Wrapper = styled.section`
+  min-height: calc(100vh - 150px);
   margin-top: 100px;
-  margin-bottom: 50px;
 `;
 
 function MyApp({ Component, pageProps }: AppProps) {

--- a/FE/pages/index.style.ts
+++ b/FE/pages/index.style.ts
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import { respondTo } from '@styles/respondTo';
 
 export const Wrapper = styled.div`
+  min-height: 8400px;
   max-width: ${({
     theme: {
       layout: { pageMaxWidth },
@@ -20,6 +21,7 @@ export const Wrapper = styled.div`
   }
 
   ${respondTo.mobile`
+    min-height: 10100px;
     margin: ${({
       theme: {
         layout: { mobileHeaderHeight },


### PR DESCRIPTION
```javascript
const Wrapper = styled.section`
  margin-top: 100px;
  margin-bottom: 50px;
`;
```
맨 위에 100px 맨 아래에 50px이 각각 네브바와 푸터가 들어갈 자리로 설정하였습니다. 
색상, 텍스트는 임의로 설정하였습니다. 추후에 수정이 필요하겠습니다. 

bug
---
용재님이 만들어주신 맨 첫 랜딩페이지에서만 푸터가 제대로 적용이 되지 않습니다. 랜딩페이지에 설정된 특정한 css 요소 떄문이지 않을까 생각이 드는데, 랜딩페이지는 우선순위가 떨어지다보니 이 부분은 추후에 수정하도록 하겠습니다.