### PR TITLE
Storybook을 각 브랜치별로 push시점에 gh-pages로 배포되도록 처리한다

### DIFF
--- a/.github/workflows/deploy-storybook-to-gh-pages.yml
+++ b/.github/workflows/deploy-storybook-to-gh-pages.yml
@@ -20,10 +20,10 @@ jobs:
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install dependencies
-        run: yarn install --prefer-offline --frozen-lockfile
+        run: cd FE && yarn install --prefer-offline --frozen-lockfile
 
       - name: Build Storybook
-        run: yarn build-storybook
+        run: cd FE && yarn build-storybook
 
       # extract branch name
       - name: Get branch name (merge)
@@ -44,7 +44,7 @@ jobs:
         if: env.BRANCH_NAME != 'master'
         with:
           github_token: ${{ secrets.GH_TOKEN }}
-          publish_dir: ./storybook-static
+          publish_dir: ./FE/storybook-static
           keep_files: true
           destination_dir: ${{ env.BRANCH_NAME }}
           commit_message: https://meet-in-ssafy.github.io/service/${{ env.BRANCH_NAME }}
@@ -54,6 +54,6 @@ jobs:
         if: env.BRANCH_NAME == 'master'
         with:
           github_token: ${{ secrets.GH_TOKEN }}
-          publish_dir: ./storybook-static
+          publish_dir: ./FE/storybook-static
           keep_files: true
           commit_message: https://meet-in-ssafy.github.io/service/

--- a/.github/workflows/deploy-storybook-to-gh-pages.yml
+++ b/.github/workflows/deploy-storybook-to-gh-pages.yml
@@ -1,0 +1,59 @@
+name: Deploy storybook to gh-pages
+
+on:
+  push:
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install dependencies
+        run: yarn install --prefer-offline --frozen-lockfile
+
+      - name: Build Storybook
+        run: yarn build-storybook
+
+      # extract branch name
+      - name: Get branch name (merge)
+        if: github.event_name != 'pull_request'
+        shell: bash
+        run: echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | sed 's/#//')" >> $GITHUB_ENV
+
+      - name: Get branch name (pull request)
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF} | sed 's/#//')" >> $GITHUB_ENV
+
+      - name: Debug
+        run: echo ${{ env.BRANCH_NAME }}
+
+      - name: Deploy to Github Pages(pr)
+        uses: peaceiris/actions-gh-pages@v3
+        if: env.BRANCH_NAME != 'master'
+        with:
+          github_token: ${{ secrets.GH_TOKEN }}
+          publish_dir: ./storybook-static
+          keep_files: true
+          destination_dir: ${{ env.BRANCH_NAME }}
+          commit_message: https://meet-in-ssafy.github.io/service/${{ env.BRANCH_NAME }}
+
+      - name: Deploy to Github Pages(master)
+        uses: peaceiris/actions-gh-pages@v3
+        if: env.BRANCH_NAME == 'master'
+        with:
+          github_token: ${{ secrets.GH_TOKEN }}
+          publish_dir: ./storybook-static
+          keep_files: true
+          commit_message: https://meet-in-ssafy.github.io/service/

--- a/FE/.gitignore
+++ b/FE/.gitignore
@@ -32,3 +32,5 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+/storybook-static

--- a/FE/package.json
+++ b/FE/package.json
@@ -9,7 +9,7 @@
     "test": "jest --watchAll --coverage",
     "lint": "next lint",
     "storybook": "start-storybook -p 6006",
-    "build-storybook": "build-storybook"
+    "build-storybook": "build-storybook -c .storybook watch-css -s ./public"
   },
   "dependencies": {
     "@reduxjs/toolkit": "^1.6.0",


### PR DESCRIPTION
> resolve [#S05P12A202-291](https://jira.ssafy.com/browse/S05P12A202-291)
* gh-pages에 브랜치별로 스토리를 배포해서 브랜치명으로 접근할 수 있도록 함

https://meet-in-ssafy.github.io/service/feature/291/

이런식으로 푸시할 때 마다 스토리북이 gh-pages에 배포되어 `https://meet-in-ssafy.github.io/service/<브랜치명>` 으로 스토리북 확인이 가능하도록 github actions를 설정하였습니다.