### PR TITLE
eslint에서 발생하는 Cannot find module 'next/babel' 문제 해결

### DIFF
--- a/FE/.eslintrc
+++ b/FE/.eslintrc
@@ -1,5 +1,5 @@
 {
-  "extends": ["next", "next/core-web-vitals", "prettier"],
+  "extends": ["next", "next/core-web-vitals", "prettier", "next/babel"],
   "plugins": ["prettier"],
   "rules": {
     "prettier/prettier": [


### PR DESCRIPTION
바벨 문제인 줄 알았는데 린트 문제였네요. 근데 이거 덕분에 바벨의 확장자 차이에 대해서 알게 되었고 이는 문서화 시키겠습니다.