### PR TITLE
화상채팅 시간 카운터 컴포넌트 구현

### DIFF
--- a/FE/components/webrtc/FloatingCounter.stories.tsx
+++ b/FE/components/webrtc/FloatingCounter.stories.tsx
@@ -1,0 +1,11 @@
+import { Story } from '@storybook/react';
+import FloatingCounter from './FloatingCounter';
+
+export default {
+  title: 'webrtc/Floating Counter',
+  component: FloatingCounter,
+};
+
+const Template: Story = () => <FloatingCounter />;
+
+export const floatingCounter = Template.bind({});

--- a/FE/components/webrtc/FloatingCounter.tsx
+++ b/FE/components/webrtc/FloatingCounter.tsx
@@ -1,0 +1,79 @@
+import { ReactElement, useState, useRef, useEffect } from 'react';
+import styled from 'styled-components';
+
+const TimerBackground = styled.div`
+  position: fixed;
+  bottom: 50px;
+  left: 40px;
+
+  width: 70px;
+  height: 15px;
+  text-align: center;
+  padding: 10px 0;
+
+  background-color: darkgray;
+  opacity: 0.4;
+  border-radius: 15px;
+`;
+
+const TimerContainer = styled.div`
+  position: fixed;
+  bottom: 50px;
+  left: 40px;
+
+  width: 70px;
+  height: 15px;
+  text-align: center;
+  padding: 10px 0;
+
+  line-height: 15px;
+  font-size: 11px;
+`;
+
+export default function FloatingTimer(): ReactElement {
+  const [count, setCount] = useState(0);
+
+  const useInterval = (callback: any, delay: number) => {
+    const savedCallback = useRef();
+
+    // Remember the latest function.
+    useEffect(() => {
+      savedCallback.current = callback;
+    }, [callback]);
+
+    // Set up the interval.
+    useEffect(() => {
+      if (delay !== null) {
+        let id = setInterval(() => {
+          savedCallback.current();
+        }, delay);
+
+        return () => clearInterval(id);
+      }
+    }, [delay]);
+  };
+
+  useInterval(() => {
+    setCount(count + 1);
+  }, 1000);
+
+  const timeToStr = (time: number) => {
+    let hour = String(Math.floor(time / 60));
+    let minute = String(time % 60);
+
+    if (hour.length == 1) hour = '0'.concat(hour);
+
+    if (minute.length == 1) minute = '0'.concat(minute);
+
+    return hour.concat(' : ', minute);
+  };
+
+  return (
+    <>
+      <TimerBackground />
+      <TimerContainer>
+        <span>{timeToStr(count)}</span>
+      </TimerContainer>
+    </>
+  );
+}

--- a/FE/components/webrtc/VideoChat.tsx
+++ b/FE/components/webrtc/VideoChat.tsx
@@ -10,6 +10,7 @@ import {
   VideoChatToolbar,
 } from '../webrtc';
 import { useAuthState } from '@store';
+import FloatingCounter from './FloatingCounter';
 
 var OpenViduBrowser: any;
 
@@ -365,6 +366,7 @@ export default function VideoChat(): ReactElement {
               handleClickAudioOn={handleClickAudioOn}
               handleClickExit={handleClickExit}
             />
+            <FloatingCounter />
           </SessionWrapper>
         </>
       )}

--- a/FE/components/webrtc/VideoChatToolbar.tsx
+++ b/FE/components/webrtc/VideoChatToolbar.tsx
@@ -2,13 +2,9 @@ import { ReactElement, useState, MouseEventHandler } from 'react';
 import styled from 'styled-components';
 import { Icon } from '@atoms';
 
-const Wrapper = styled.div`
-  ${({ theme: { flexCol } }) => flexCol()}
-`;
-
 const ToolbarBackground = styled.div`
   position: fixed;
-  bottom: 70px;
+  bottom: 50px;
   left: 50%;
   transform: translateX(-50%);
 
@@ -24,7 +20,7 @@ const ToolbarBackground = styled.div`
 
 const ToolbarContainer = styled.div`
   position: fixed;
-  bottom: 70px;
+  bottom: 50px;
   left: 50%;
   transform: translateX(-50%);
 
@@ -60,7 +56,7 @@ export default function VideoChatToolbar({
   handleClickExit,
 }: VideoChatToolbarProps): ReactElement {
   return (
-    <Wrapper>
+    <>
       <ToolbarBackground />
       <ToolbarContainer>
         {camOn ? (
@@ -88,6 +84,6 @@ export default function VideoChatToolbar({
           <Icon iconName="logout" />
         </span>
       </ToolbarContainer>
-    </Wrapper>
+    </>
   );
 }

--- a/FE/components/webrtc/VideoRoomConfigModal.tsx
+++ b/FE/components/webrtc/VideoRoomConfigModal.tsx
@@ -16,7 +16,7 @@ import { OpenViduVideoComponent } from '../webrtc';
 import { LoggerUtil } from './util/LoggerUtil';
 import { DevicesUtil } from './util/DeviceUtil';
 import { Util } from './util/Util';
-import { IDevice, CameraType } from './types/device-type';
+import { IDevice } from './types/device-type';
 
 interface VideoRoomConfigModalProps {
   OV: OpenVidu;


### PR DESCRIPTION
> resolve [#S05P12A202-254](https://jira.ssafy.com/browse/S05P12A202-254)

원래 [#S05P12A202-254](https://jira.ssafy.com/browse/S05P12A202-254)는 통화시간 뿐 아니라 유저의 프로필 또는 이름 표시도 포함하지만, 유저의 프로필 또는 이름 표시는 #45 에서 구현하였습니다.

화상채팅 내에 카운터(통화시간)를 구현합니다. 이 카운터는 사용자가 세션에 참여하면 시작되며 사용자가 얼마나 오래 세션에 있었는지를 나타냅니다. (세션이 얼마나 오래 켜져있었는지를 나타내지 않습니다)

카운터 구현하면서 `setInterval`을 사용하는데 조금 생소한 부분이 있어서 참고했던 자료 공유합니다.
https://velog.io/@jakeseo_me/%EB%B2%88%EC%97%AD-%EB%A6%AC%EC%95%A1%ED%8A%B8-%ED%9B%85%EC%8A%A4-%EC%BB%B4%ED%8F%AC%EB%84%8C%ED%8A%B8%EC%97%90%EC%84%9C-setInterval-%EC%82%AC%EC%9A%A9-%EC%8B%9C%EC%9D%98-%EB%AC%B8%EC%A0%9C%EC%A0%90

https://team-gu.github.io/service/feature/254/?path=/story/webrtc-floating-counter--floating-counter