### PR TITLE
next.config.js에 ts.ignoreBuildErrors 옵션을 추가한다

### DIFF
--- a/FE/next.config.js
+++ b/FE/next.config.js
@@ -2,6 +2,9 @@ const path = require('path');
 
 module.exports = {
   reactStrictMode: true,
+  typescript: {
+    ignoreBuildErrors: true,
+  },
   webpack(config, options) {
     config.resolve = {
       alias: {


### PR DESCRIPTION
* 해당 옵션이 없으면 타입에러가 완벽하게 없을때만 빌드가능