### PR TITLE
유저디테일 레이아웃을 완성합니다

### DIFF
--- a/FE/components/organisms/UserDetail/UserDetail.stories.tsx
+++ b/FE/components/organisms/UserDetail/UserDetail.stories.tsx
@@ -1,0 +1,11 @@
+import { Meta } from '@storybook/react';
+import UserDetail from './UserDetail';
+
+export default {
+  title: 'Organisms/UserDetail',
+  component: UserDetail,
+} as Meta;
+
+const Template = () => <UserDetail />;
+
+export const userDetail = Template.bind({});

--- a/FE/components/organisms/UserDetail/UserDetail.stories.tsx
+++ b/FE/components/organisms/UserDetail/UserDetail.stories.tsx
@@ -2,7 +2,7 @@ import { Meta } from '@storybook/react';
 import UserDetail from './UserDetail';
 
 export default {
-  title: 'Organisms/UserDetail',
+  title: 'Organisms/User Detail',
   component: UserDetail,
 } as Meta;
 

--- a/FE/components/organisms/UserDetail/UserDetail.tsx
+++ b/FE/components/organisms/UserDetail/UserDetail.tsx
@@ -18,6 +18,7 @@ const Icons = styled.div`
 
   i {
     padding-left: 10px;
+    curosr: pointer;
   }
 `;
 
@@ -37,6 +38,9 @@ const Manifesto = styled.div`
     width: 80%;
     & + * {
       margin-top: 1em;
+    }
+    .track {
+      width: 30%;
     }
   }
 `;
@@ -100,7 +104,7 @@ export default function UserDetail(): ReactElement {
         <Manifesto>
           <p>지역 기수 반 이름</p>
           <div>
-            <p style={{ width: '30%' }}>트랙</p>
+            <p className="track">트랙</p>
             <p>희망포지션</p>
           </div>
           <p>

--- a/FE/components/organisms/UserDetail/UserDetail.tsx
+++ b/FE/components/organisms/UserDetail/UserDetail.tsx
@@ -1,0 +1,129 @@
+import { ReactElement } from 'react';
+import Link from 'next/link';
+import { Icon } from '@atoms';
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  width: 60vw;
+  margin: 0 auto 20px auto;
+  border-radius: 3px;
+  box-shadow: 2px 2px 8px black;
+`;
+
+const Icons = styled.div`
+  margin: 30px;
+  display: flex;
+  justify-content: flex-end;
+
+  i {
+    padding-left: 10px;
+  }
+`;
+
+const Introduction = styled.div`
+  margin: auto;
+  display: grid;
+  grid-template-columns: 1fr 0.5fr;
+  gap: 40px;
+`;
+
+const Manifesto = styled.div`
+  p {
+    font-size: 20px;
+    font-weight: 600;
+    line-height: 1.4;
+    margin: 50px;
+    width: 80%;
+    & + * {
+      margin-top: 1em;
+    }
+  }
+`;
+
+const Portrait = styled.div`
+  width: 100%;
+  overflow: hidden;
+
+  img {
+    width: 70%;
+    height: auto;
+    margin-top: 15vh;
+  }
+`;
+
+const Projects = styled.div`
+  grid-column: span 3;
+  display: grid;
+  grid-gap: 20px;
+  grid-template-columns: 1fr 1fr 1fr;
+  margin: 50px;
+
+  /* Todo: 미디어 쿼리가 제대로 안먹음 */
+  /* @media (max-width: 768px) {
+    grid-column: span 2;
+    grid-template-columns: 1fr 1fr;
+  } */
+
+  p {
+    grid-column: span 3;
+    font-size: 20px;
+    font-weight: 600;
+    line-height: 1.4;
+    width: 80%;
+  }
+`;
+
+const Card = styled.div`
+  border: 1px solid #eaeaea;
+  padding: 24px;
+  border-radius: 5px;
+  text-align: left;
+  height: 80px;
+  flex: 1.1;
+  transition: box-shadow 0.2s;
+  &:hover {
+    box-shadow: 1px 1px 1px 1px rgba(0, 0, 0, 0.1);
+  }
+`;
+
+export default function UserDetail(): ReactElement {
+  return (
+    <Wrapper>
+      <Icons>
+        <Icon iconName="edit" color="black" />
+        <Icon iconName="person_add_alt" color="black" />
+        <Icon iconName="chat" color="black" />
+        <Icon iconName="call" color="black" />
+      </Icons>
+      <Introduction>
+        <Manifesto>
+          <p>지역 기수 반 이름</p>
+          <div>
+            <p style={{ width: '30%' }}>트랙</p>
+            <p>희망포지션</p>
+          </div>
+          <p>
+            I mostly spend time developing, designing and surfing the web while
+            Music or watching Netflix. Endless learning keeps me alive and never
+            hangs me down to the past.
+          </p>
+        </Manifesto>
+        <Portrait>
+          <img
+            className="default-image"
+            alt="프로필이미지"
+            src="/profile.png"
+          />
+        </Portrait>
+        <Projects>
+          <p>프로젝트</p>
+          <Card>ssss</Card>
+          <Card>ssss</Card>
+          <Card>ssss</Card>
+          <Card>ssss</Card>
+        </Projects>
+      </Introduction>
+    </Wrapper>
+  );
+}

--- a/FE/components/organisms/UserDetail/index.ts
+++ b/FE/components/organisms/UserDetail/index.ts
@@ -1,0 +1,1 @@
+export { default } from './UserDetail';

--- a/FE/components/organisms/index.ts
+++ b/FE/components/organisms/index.ts
@@ -5,6 +5,7 @@ import Modal from './Modal';
 import Navbar from './Navbar';
 import Footer from './Footer';
 import Layout from './Layout';
+import UserDetail from './UserDetail';
 import LineBackground from './LineBackground';
 import LoginComponent from './LoginComponent';
 import RegisterComponent from './RegisterComponent';
@@ -17,6 +18,7 @@ export {
   Navbar,
   Footer,
   Layout,
+  UserDetail,
   LineBackground,
   LoginComponent,
   RegisterComponent,

--- a/FE/pages/userdetail/index.tsx
+++ b/FE/pages/userdetail/index.tsx
@@ -1,9 +1,10 @@
 import { ReactElement } from 'react';
+import { UserDetail } from '@organisms';
 
-export default function UserDetail(): ReactElement {
+export default function UserDetailPage(): ReactElement {
   return (
     <>
-      <h1>This is template UserDetail</h1>
+      <UserDetail />
     </>
   );
 }


### PR DESCRIPTION
> resolve [#S05P12A202-166](https://jira.ssafy.com/browse/S05P12A202-166)

미디어 쿼리가 제대로 작동하지 않아서 이 부분을 조금 더 찾아봐야 할 것 같습니다.

최대한 저희 초기 디자인 버전과 비슷하게 만들어보려고 노력하였습니다.
현재 아이콘이 있으나 해당 아이콘이 무슨 기능을 하는지 유저가 알기 어려운 것 같습니다. 
https://demos.creative-tim.com/nextjs-material-kit-pro/documentation/tooltips
해당 툴팁을 써보면 어떨까 라는 생각이 들었습니다.

해당 페이지에서 총 3가지 버전이 필요하게 될 텐데 (로그인한 유저의 정보를 보여주는 페이지, 로그인한 유저일 경우 해당 box들을 모두 input으로 바꾸어서 보여주는 페이지, 다른 유저의 정보를 보여주는 페이지) 이 부분에 대한 고민이 조금 필요할 것 같습니다.