### PR TITLE
카메라 켜져야 마이크가 켜지는 버그 수정

### DIFF
--- a/FE/components/webrtc/OpenViduVideoComponent.tsx
+++ b/FE/components/webrtc/OpenViduVideoComponent.tsx
@@ -12,6 +12,7 @@ const Wrapper = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
+  position: relative;
 
   video {
     min-width: 100%;

--- a/FE/components/webrtc/OpenViduVideoComponent.tsx
+++ b/FE/components/webrtc/OpenViduVideoComponent.tsx
@@ -17,12 +17,28 @@ const Wrapper = styled.div`
     min-width: 100%;
   }
 
-  .image-margin-30 > div {
-    margin: 30px;
+  .alt-image {
+    margin: auto;
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: -1px;
+    right: 0;
+    background-color: white;
+    box-shadow: 0px 0px 10px 1px rgb(0 0 255 / 20%);
+
+    > div {
+      margin: auto;
+      position: absolute;
+      top: 0;
+      left: 0;
+      bottom: 0;
+      right: 0;
+    }
   }
 `;
 
-export default function UserVideoComponent({
+export default function OpenViduVideoComponent({
   streamManager,
 }: OpenViduVideoComponentProps): ReactElement {
   const videoRef = useRef<HTMLVideoElement>(null);
@@ -36,10 +52,9 @@ export default function UserVideoComponent({
 
   return (
     <Wrapper>
-      {streamManager.stream.videoActive ? (
-        <video autoPlay={true} ref={videoRef} />
-      ) : (
-        <div className="image-margin-30">
+      <video autoPlay={true} ref={videoRef} />
+      {!streamManager.stream.videoActive && (
+        <div className="alt-image">
           <ProfileImage src={'/profile.png'} size={230} />
         </div>
       )}

--- a/FE/components/webrtc/VideoChat.tsx
+++ b/FE/components/webrtc/VideoChat.tsx
@@ -1,10 +1,5 @@
 import { ReactElement, useState, useEffect } from 'react';
-import {
-  OpenVidu,
-  Session,
-  Subscriber,
-  Publisher,
-} from 'openvidu-browser';
+import { OpenVidu, Session, Subscriber, Publisher } from 'openvidu-browser';
 import { useRouter } from 'next/router';
 import styled from 'styled-components';
 import axios from 'axios';
@@ -42,7 +37,6 @@ const SessionContainer = styled.div<{ number: number }>`
 
   .flexItem {
     align-self: stretch;
-    border: solid 1px gainsboro;
   }
 
   ${({ number }) => {
@@ -133,22 +127,6 @@ export default function VideoChat(): ReactElement {
     leaveSession();
   };
 
-  const updateSubscriber = (connectionId: string, prop: string, newValue: any) => {
-    const subs = subscribers;
-
-    subs.map((sub) => {
-      if (sub.stream.connection.connectionId === connectionId) {
-        if (prop === 'audioActive')  {
-          sub.stream.audioActive = newValue;
-        } else if (prop === 'videoActive') {
-          sub.stream.videoActive = newValue;
-        }
-      }
-    });
-
-    setSubscribers([...subs]);
-  }
-
   const deleteSubscriber = (streamManager: Subscriber) => {
     let subs = subscribers;
     let index = subscribers.indexOf(streamManager, 0);
@@ -189,9 +167,6 @@ export default function VideoChat(): ReactElement {
     setMicOn(micState);
     setCamOn(camState);
 
-    console.log(micState);
-    console.log(camState);
-
     setIsConfigModalShow(false);
     setSession(OV?.initSession());
   };
@@ -221,13 +196,17 @@ export default function VideoChat(): ReactElement {
     });
 
     // 스트림 속성이 변경되면
-    mySession.on('streamPropertyChanged', (event: any) => {
-      const prop = event.changedProperty;
-      const newValue = event.newValue;
-      const connectionId = event.stream.connection.connectionId;
-      // updateSubscriber(connectionId, prop, newValue);
+    mySession.on('streamPropertyChanged', () => {
+      const subs = subscribers;
+      setSubscribers([...subs]);
+    });
 
-      setSubscribers([...subscribers]);
+    mySession.on('publisherStartSpeaking', (event: any) => {
+      console.log('User ' + event.connection.connectionId + ' start speaking');
+    });
+
+    mySession.on('publisherStopSpeaking', (event: any) => {
+      console.log('User ' + event.connection.connectionId + ' stop speaking');
     });
 
     getToken()
@@ -323,7 +302,7 @@ export default function VideoChat(): ReactElement {
   };
 
   const handleClickAudioOff = () => {
-    publisher?.publishAudio(false); 
+    publisher?.publishAudio(false);
     setMicOn(false);
   };
 

--- a/FE/components/webrtc/VideoChat.tsx
+++ b/FE/components/webrtc/VideoChat.tsx
@@ -63,8 +63,8 @@ const SessionContainer = styled.div<{ number: number }>`
 `;
 
 interface UserDevice {
-  mic: string;
-  cam: string;
+  mic: string | undefined;
+  cam: string | undefined;
 }
 
 const OPENVIDU_SERVER_URL = 'https://teamgu.xyz';
@@ -78,10 +78,7 @@ export default function VideoChat(): ReactElement {
   const [publisher, setPublisher] = useState<Publisher>();
   const [subscribers, setSubscribers] = useState<Subscriber[]>([]);
   const [isConfigModalShow, setIsConfigModalShow] = useState<boolean>(true);
-  const [userDevice, setUserDevice] = useState<UserDevice>({
-    mic: '',
-    cam: '',
-  });
+  const [userDevice, setUserDevice] = useState<UserDevice>({ mic: undefined, cam: undefined });
 
   const [micOn, setMicOn] = useState(false);
   const [camOn, setCamOn] = useState(false);
@@ -154,11 +151,14 @@ export default function VideoChat(): ReactElement {
   };
 
   const handlerJoinBtn = (
-    micSelected: string,
-    camSelected: string,
+    micSelected: string | undefined,
+    camSelected: string | undefined,
     micState: boolean,
     camState: boolean,
   ) => {
+    if (micSelected && camSelected) {
+      
+    }
     setUserDevice({
       mic: micSelected,
       cam: camSelected,
@@ -215,8 +215,8 @@ export default function VideoChat(): ReactElement {
           if (!OV) return;
 
           let publisher = OV.initPublisher('', {
-            audioSource: userDevice.mic,
-            videoSource: userDevice.cam,
+            audioSource: userDevice.mic ? userDevice.mic : false,
+            videoSource: userDevice.cam ? userDevice.cam : false,
             publishAudio: micOn,
             publishVideo: camOn,
             resolution: '640x480',
@@ -291,25 +291,19 @@ export default function VideoChat(): ReactElement {
     });
   };
 
-  const handleClickVideoOff = () => {
-    publisher?.publishVideo(false);
-    setCamOn(false);
-  };
+  const handleVideoStateChanged = () => {
+    if (userDevice.cam) {
+      publisher?.publishVideo(!camOn);
+      setCamOn(!camOn);
+    }    
+  }
 
-  const handleClickVideoOn = () => {
-    publisher?.publishVideo(true);
-    setCamOn(true);
-  };
-
-  const handleClickAudioOff = () => {
-    publisher?.publishAudio(false);
-    setMicOn(false);
-  };
-
-  const handleClickAudioOn = () => {
-    publisher?.publishAudio(true);
-    setMicOn(true);
-  };
+  const handleAudioStateChanged = () => {
+    if (userDevice.mic) {
+      publisher?.publishAudio(!micOn);
+      setMicOn(!micOn);
+    }
+  }
 
   const handleClickExit = () => {
     leaveSession();
@@ -376,10 +370,10 @@ export default function VideoChat(): ReactElement {
               <VideoChatToolbar
                 micOn={micOn}
                 camOn={camOn}
-                handleClickVideoOff={handleClickVideoOff}
-                handleClickVideoOn={handleClickVideoOn}
-                handleClickAudioOff={handleClickAudioOff}
-                handleClickAudioOn={handleClickAudioOn}
+                handleClickVideoOff={handleVideoStateChanged}
+                handleClickVideoOn={handleVideoStateChanged}
+                handleClickAudioOff={handleAudioStateChanged}
+                handleClickAudioOn={handleAudioStateChanged}
                 handleClickExit={handleClickExit}
                 handleClickScreenShare={handleClickScreenShare}
                 handleClickGame={handleClickGame}

--- a/FE/components/webrtc/VideoRoomConfigModal.tsx
+++ b/FE/components/webrtc/VideoRoomConfigModal.tsx
@@ -122,8 +122,8 @@ export default function VideoRoomConfigModal({
   const [micSelected, setMicSelected] = useState<string>('');
   const [localCamStream, setLocalCamStream] = useState<Publisher>();
 
-  const [camOn, setCamOn] = useState(true);
-  const [micOn, setMicOn] = useState(true);
+  const [camOn, setCamOn] = useState(false);
+  const [micOn, setMicOn] = useState(false);
 
   useEffect(() => {
     (async function init() {

--- a/FE/components/webrtc/VideoRoomConfigModal.tsx
+++ b/FE/components/webrtc/VideoRoomConfigModal.tsx
@@ -23,8 +23,8 @@ interface VideoRoomConfigModalProps {
   sessionTitle: string;
   handlerClose: MouseEventHandler;
   handlerJoin: (
-    micSelected: string,
-    camSelected: string,
+    micSelected: string | undefined,
+    camSelected: string | undefined,
     micState: boolean,
     camState: boolean,
   ) => void;
@@ -118,8 +118,8 @@ export default function VideoRoomConfigModal({
 }: VideoRoomConfigModalProps): ReactElement {
   const [cameras, setCameras] = useState<IDevice[]>([]);
   const [microphones, setMicrophones] = useState<IDevice[]>([]);
-  const [camSelected, setCamSelected] = useState<string>('');
-  const [micSelected, setMicSelected] = useState<string>('');
+  const [camSelected, setCamSelected] = useState<string>();
+  const [micSelected, setMicSelected] = useState<string>();
   const [localCamStream, setLocalCamStream] = useState<Publisher>();
 
   const [camOn, setCamOn] = useState(true);
@@ -131,13 +131,23 @@ export default function VideoRoomConfigModal({
       util = new Util();
       devicesUtil = new DevicesUtil(OV, loggerUtil, util);
 
-      // To get user's permission of video and audio
-      await OV.initPublisherAsync('', {
-        resolution: '320x240',
-      });
+      try {
+        // To get user's permission of video and audio
+        await OV.initPublisherAsync('', {
+          resolution: '320x240',
+        });
 
-      // After permit, get devices
-      await devicesUtil.initDevices();
+        // After permit, get devices
+        await devicesUtil.initDevices();
+      } catch (e) {
+        console.error(e.message);
+        if (e.name === 'DEVICE_ACCESS_DENIED') {
+          alert('장치에 접근할 수 없습니다.');
+          setCamOn(false);
+          setMicOn(false);
+        }
+      }
+
       setMicrophones([...devicesUtil.getMicrophones()]);
       setCameras([...devicesUtil.getCameras()]);
 
@@ -155,11 +165,12 @@ export default function VideoRoomConfigModal({
     setMicSelected(event.target.value);
   };
 
+  // TODO: 카메라가 필요없는 None을 선택해도 On-Air 불빛이 꺼지지 않는다.
   // Publish every time the camera changes
   useEffect(() => {
-    // TODO: 카메라가 필요없는 None을 선택해도 On-Air 불빛이 꺼지지 않는다.
-
-    if (camSelected || camSelected === '') publishUserCameraStream();
+    if (camSelected) {
+      publishUserCameraStream();
+    }
   }, [camSelected]);
 
   const publishUserCameraStream = () => {
@@ -176,17 +187,21 @@ export default function VideoRoomConfigModal({
   };
 
   const handleCamOnChanged = () => {
-    localCamStream?.publishVideo(!camOn);
-    setCamOn(!camOn);
+    if (camSelected) {
+      localCamStream?.publishVideo(!camOn);
+      setCamOn(!camOn);
+    }
   };
 
   const handleMicOnChanged = () => {
-    setMicOn(!micOn);
+    if (micSelected) {
+      setMicOn(!micOn);
+    }
   };
 
   const handleClickJoin = () => {
     handlerJoin(micSelected, camSelected, micOn, camOn);
-  }
+  };
 
   return (
     <ModalWrapper modalName="videoConfigModal">

--- a/FE/components/webrtc/VideoRoomConfigModal.tsx
+++ b/FE/components/webrtc/VideoRoomConfigModal.tsx
@@ -22,7 +22,12 @@ interface VideoRoomConfigModalProps {
   OV: OpenVidu;
   sessionTitle: string;
   handlerClose: MouseEventHandler;
-  handlerJoin: (micSelected: string, camSelected: string) => void;
+  handlerJoin: (
+    micSelected: string,
+    camSelected: string,
+    micState: boolean,
+    camState: boolean,
+  ) => void;
 }
 
 const SessionTitle = styled.span`
@@ -117,6 +122,9 @@ export default function VideoRoomConfigModal({
   const [micSelected, setMicSelected] = useState<string>('');
   const [localCamStream, setLocalCamStream] = useState<Publisher>();
 
+  const [camOn, setCamOn] = useState(true);
+  const [micOn, setMicOn] = useState(true);
+
   useEffect(() => {
     (async function init() {
       loggerUtil = new LoggerUtil();
@@ -177,6 +185,14 @@ export default function VideoRoomConfigModal({
     setLocalCamStream(stream);
   };
 
+  const handlecamOnChanged = () => {
+    setCamOn(!camOn);
+  };
+
+  const handleMicOnChanged = () => {
+    setMicOn(!micOn);
+  };
+
   return (
     <ModalWrapper modalName="videoConfigModal">
       <GridContainer>
@@ -207,7 +223,16 @@ export default function VideoRoomConfigModal({
                 readOnly={true}
               />
             </div>
-            <Icon iconName="mic" color="gray" />
+
+            <div>
+              <Icon iconName="mic" color="gray" />
+              <input
+                type="checkbox"
+                checked={micOn}
+                onChange={handleMicOnChanged}
+              />
+            </div>
+
             <Label text="Microphone">
               <select value={micSelected} onChange={handleMicrophoneChange}>
                 {microphones?.map((mic, i) => (
@@ -217,7 +242,16 @@ export default function VideoRoomConfigModal({
                 ))}
               </select>
             </Label>
-            <Icon iconName="videocam" color="gray" />
+
+            <div>
+              <Icon iconName="videocam" color="gray" />
+              <input
+                type="checkbox"
+                checked={camOn}
+                onChange={handlecamOnChanged}
+              />
+            </div>
+
             <Label text="Camera">
               <select value={camSelected} onChange={handleCameraChange}>
                 {cameras?.map((cam, i) => (
@@ -232,7 +266,7 @@ export default function VideoRoomConfigModal({
         <div className="modal-footer">
           <Button
             title="JOIN"
-            func={() => handlerJoin(micSelected, camSelected)}
+            func={() => handlerJoin(micSelected, camSelected, micOn, camOn)}
           />
         </div>
       </GridContainer>

--- a/FE/components/webrtc/VideoRoomConfigModal.tsx
+++ b/FE/components/webrtc/VideoRoomConfigModal.tsx
@@ -122,8 +122,8 @@ export default function VideoRoomConfigModal({
   const [micSelected, setMicSelected] = useState<string>('');
   const [localCamStream, setLocalCamStream] = useState<Publisher>();
 
-  const [camOn, setCamOn] = useState(false);
-  const [micOn, setMicOn] = useState(false);
+  const [camOn, setCamOn] = useState(true);
+  const [micOn, setMicOn] = useState(true);
 
   useEffect(() => {
     (async function init() {
@@ -163,21 +163,11 @@ export default function VideoRoomConfigModal({
   }, [camSelected]);
 
   const publishUserCameraStream = () => {
-    const micIsNone = !micSelected || micSelected === '';
-    const camIsNone = !camSelected || camSelected === '';
-
-    if (camIsNone && localCamStream) {
-      localCamStream.publishVideo(false);
-      // TODO: 타입 에러 localCamStream
-      setLocalCamStream({ ...localCamStream });
-      return;
-    }
-
     const stream = OV.initPublisher('', {
-      audioSource: micIsNone ? undefined : micSelected,
-      videoSource: camIsNone ? undefined : camSelected,
+      audioSource: micSelected,
+      videoSource: camSelected,
       publishAudio: false,
-      publishVideo: camIsNone ? false : true,
+      publishVideo: camOn,
       resolution: '320x240',
       frameRate: 30,
       mirror: true,
@@ -186,6 +176,7 @@ export default function VideoRoomConfigModal({
   };
 
   const handleCamOnChanged = () => {
+    localCamStream?.publishVideo(!camOn);
     setCamOn(!camOn);
   };
 
@@ -208,7 +199,7 @@ export default function VideoRoomConfigModal({
         </CloseBtn>
 
         <div className="self-video">
-          {localCamStream !== undefined && (
+          {localCamStream && (
             <OpenViduVideoComponent streamManager={localCamStream} />
           )}
         </div>
@@ -228,14 +219,11 @@ export default function VideoRoomConfigModal({
               />
             </div>
 
-            <div>
-              <Icon iconName="mic" color="gray" />
-              <input
-                type="checkbox"
-                checked={micOn}
-                onChange={handleMicOnChanged}
-              />
-            </div>
+            {micOn ? (
+              <Icon iconName="mic" color="gray" func={handleMicOnChanged} />
+            ) : (
+              <Icon iconName="mic_off" color="gray" func={handleMicOnChanged} />
+            )}
 
             <Label text="Microphone">
               <select value={micSelected} onChange={handleMicrophoneChange}>
@@ -247,14 +235,19 @@ export default function VideoRoomConfigModal({
               </select>
             </Label>
 
-            <div>
-              <Icon iconName="videocam" color="gray" />
-              <input
-                type="checkbox"
-                checked={camOn}
-                onChange={handleCamOnChanged}
+            {camOn ? (
+              <Icon
+                iconName="videocam"
+                color="gray"
+                func={handleCamOnChanged}
               />
-            </div>
+            ) : (
+              <Icon
+                iconName="videocam_off"
+                color="gray"
+                func={handleCamOnChanged}
+              />
+            )}
 
             <Label text="Camera">
               <select value={camSelected} onChange={handleCameraChange}>
@@ -268,10 +261,7 @@ export default function VideoRoomConfigModal({
           </IconsAndInputs>
         </div>
         <div className="modal-footer">
-          <Button
-            title="JOIN"
-            func={handleClickJoin}
-          />
+          <Button title="JOIN" func={handleClickJoin} />
         </div>
       </GridContainer>
     </ModalWrapper>

--- a/FE/components/webrtc/VideoRoomConfigModal.tsx
+++ b/FE/components/webrtc/VideoRoomConfigModal.tsx
@@ -185,13 +185,17 @@ export default function VideoRoomConfigModal({
     setLocalCamStream(stream);
   };
 
-  const handlecamOnChanged = () => {
+  const handleCamOnChanged = () => {
     setCamOn(!camOn);
   };
 
   const handleMicOnChanged = () => {
     setMicOn(!micOn);
   };
+
+  const handleClickJoin = () => {
+    handlerJoin(micSelected, camSelected, micOn, camOn);
+  }
 
   return (
     <ModalWrapper modalName="videoConfigModal">
@@ -248,7 +252,7 @@ export default function VideoRoomConfigModal({
               <input
                 type="checkbox"
                 checked={camOn}
-                onChange={handlecamOnChanged}
+                onChange={handleCamOnChanged}
               />
             </div>
 
@@ -266,7 +270,7 @@ export default function VideoRoomConfigModal({
         <div className="modal-footer">
           <Button
             title="JOIN"
-            func={() => handlerJoin(micSelected, camSelected, micOn, camOn)}
+            func={handleClickJoin}
           />
         </div>
       </GridContainer>

--- a/FE/components/webrtc/util/DeviceUtil.ts
+++ b/FE/components/webrtc/util/DeviceUtil.ts
@@ -24,13 +24,13 @@ export class DevicesUtil {
     this.resetDevicesArray();
     if (this.hasAudioDeviceAvailable()) {
       this.initAudioDevices();
-      const defaultMic = this.microphones.find((device) => device.device === 'default');
-      this.micSelected = defaultMic ? defaultMic : this.microphones[0];
+      // const defaultMic = this.microphones.find((device) => device.device === 'default');
+      this.micSelected = this.microphones[0];
     }
     if (this.hasVideoDeviceAvailable()) {
       this.initVideoDevices();
-      const defaultCam = this.cameras.find((device) => device.type === CameraType.FRONT);
-      this.camSelected = defaultCam ? defaultCam : this.cameras[0]
+      // const defaultCam = this.cameras.find((device) => device.type === CameraType.FRONT);
+      this.camSelected = this.cameras[0]
     }
   }
   private async initOpenViduDevices() {
@@ -104,8 +104,8 @@ export class DevicesUtil {
   }
 
   private resetDevicesArray() {
-    this.cameras = [{ label: 'None', device: '', type: undefined }];
-    this.microphones = [{ label: 'None', device: '', type: undefined }];
+    this.cameras = [];
+    this.microphones = [];
   }
 
 


### PR DESCRIPTION
> resolve [#S05P12A202-320](https://jira.ssafy.com/browse/S05P12A202-320)

### 버그

카메라를 켜지 않으면 마이크가 들리지 않는다.

### 해결

- 비디오 또는 오디오를 끄거나 키는 것은 퍼블리싱 하냐 마냐로 결정한다. (videoSource, audioSource는 항상 존재)
- 따라서 처음 설정 모달에서 None 선택지를 없앤다. 대신 on/off 토글을 추가한다. 
- 직접적으로 화면을 보여주는 `video` 태그를 항상 렌더링한다. 이전에는 비디오가 없으면 video 태그를 렌더링하지 않아서 오디오는 들리지 않았던 것이다.
- video 태그는 항상 렌더링하고, 비디오가 없으면 이미지를 그 위에 덮어씌운다.
- 크기에 맞춰서 덮어씌우면 가끔 1px정도 이미지보다 video 태그 검정화면이 더 클 때가 있어서 이미지 크기에 대해서 bottom을 1px 늘리고 그에 따라서 border가 숨겨지므로 shadow로 처리했다.

### To do

- [x] 화상채팅 설정 모달에서 on/off  토글 (지금은 그냥 체크박스 형태)
- [x] 사용자에게 적절한 마이크 또는 카메라 디바이스가 없는 경우 처리
- [x] 화상채팅 설정 모달에서 처음에 잠깐 대체 이미지가 잘못된 위치에 렌더링 됨

@dididy @Dongkyun-Jang 