### PR TITLE
공통 컴포넌트 SkillSelectAutoComplete

### DIFF
--- a/FE/components/molecules/SkillSelectAutoComplete/SkillSelectAutoComplete.stories.tsx
+++ b/FE/components/molecules/SkillSelectAutoComplete/SkillSelectAutoComplete.stories.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Story } from '@storybook/react';
+import SkillSelectAutoComplete from './SkillSelectAutoComplete';
+
+export default {
+  title: 'Molecules/Skill Select Auto Complete',
+  component: SkillSelectAutoComplete,
+};
+
+const Template: Story = () => (
+  <SkillSelectAutoComplete
+    handleChangeSkillSelect={(value) => console.log(value)}
+  />
+);
+
+export const skillSelectAutoComplete = Template.bind({});

--- a/FE/components/molecules/SkillSelectAutoComplete/SkillSelectAutoComplete.tsx
+++ b/FE/components/molecules/SkillSelectAutoComplete/SkillSelectAutoComplete.tsx
@@ -1,0 +1,35 @@
+import { ReactElement, useState, useEffect } from 'react';
+import Select from 'react-select';
+import { getSkillList } from '@repository/baseRepository';
+
+interface SkillSelectAutoCompleteProps {
+  handleChangeSkillSelect: (newValue: object) => void;
+}
+
+export default function SkillSelectAutoComplete({
+  handleChangeSkillSelect,
+}: SkillSelectAutoCompleteProps): ReactElement {
+  const [skillOptions, setSkillOptions] = useState([]);
+
+  const loadSkills = async () => {
+    const skillList = await getSkillList();
+    const options = skillList.map((sk) => {
+      return { label: sk.skill, value: sk.skill, id: sk.id };
+    });
+    return options;
+  };
+
+  useEffect(() => {
+    loadSkills().then((data) => {
+      setSkillOptions(data);
+    });
+  }, []);
+
+  return (
+    <Select
+      isMulti
+      options={skillOptions}
+      onChange={(item) => handleChangeSkillSelect(item)}
+    />
+  );
+}

--- a/FE/components/molecules/SkillSelectAutoComplete/index.ts
+++ b/FE/components/molecules/SkillSelectAutoComplete/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SkillSelectAutoComplete';

--- a/FE/components/molecules/UserSelectAutoComplete/UserSelectAutoComplete.tsx
+++ b/FE/components/molecules/UserSelectAutoComplete/UserSelectAutoComplete.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useState } from 'react';
+import { ReactElement } from 'react';
 import { OptionTypeBase } from 'react-select';
 import AsyncSelect from 'react-select/async';
 import { getUserListByNameContains } from '@repository/baseRepository';

--- a/FE/repository/baseRepository.ts
+++ b/FE/repository/baseRepository.ts
@@ -71,3 +71,38 @@ export const getUserListByNameContains = async (param: string) => {
   //   type: 'get',
   // });
 };
+
+export const getSkillList = async () => {
+
+  return new Promise<any>(resolve => {
+    const dummy = [
+      {
+        skill: 'React',
+        id: 1,
+      },
+      {
+        skill: 'IoT',
+        id: 2,
+      },
+      {
+        skill: 'Spring',
+        id: 3,
+      },
+      {
+        skill: 'WebRTC',
+        id: 4,
+      },
+      {
+        skill: 'MySQL',
+        id: 5,
+      },
+    ];
+
+    resolve(dummy);
+  })
+  // TODO: api 연결 백엔드 미완.
+  // return await api({
+  //   url: `/path/to/get-skill-list`,
+  //   type: 'get',
+  // });
+};


### PR DESCRIPTION
> Resolve [#S05P13A202-205](https://jira.ssafy.com/browse/S05P13A202-205)

- Select에서 여러개 선택할 수 있다
- 처음 로딩될 때, 서버로부터 스킬 리스트를 가져오는 API 호출 로직을 포함
- 현재는 API는 백엔드가 미완이므로 더미데이터를 반환

@dididy @Dongkyun-Jang 