### PR TITLE
Input에 ref를 사용할 때 value를 사용할 수 없는 현상 해결

### DIFF
--- a/FE/components/atoms/Input/Input.tsx
+++ b/FE/components/atoms/Input/Input.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/display-name */
 import {
   ReactElement,
+  useEffect,
   ChangeEvent,
   forwardRef,
   KeyboardEventHandler,
@@ -22,6 +23,7 @@ interface InputProps {
   error?: string;
   readOnly?: boolean;
   value?: string;
+  refValue?: string;
 }
 
 const Wrapper = styled.div<{
@@ -71,10 +73,21 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
       error,
       readOnly = false,
       value,
+      refValue = '',
     }: InputProps,
     ref,
   ): ReactElement => {
     // TODO: 추후 any 제거
+
+    // TODO: current에 대한 타입 지정
+    useEffect(() => {
+      if (ref && refValue) {
+        if (ref.current) {
+          ref.current.value = refValue;
+        }
+      }
+    }, []);
+
     return (
       <Wrapper
         className="input"

--- a/FE/components/atoms/Textarea/Textarea.tsx
+++ b/FE/components/atoms/Textarea/Textarea.tsx
@@ -1,13 +1,24 @@
-import { ReactElement, forwardRef, ReactNode } from 'react';
+import { ReactElement, useEffect, forwardRef, ReactNode } from 'react';
 
 interface TextareaProps {
-  children: ReactNode;
+  children?: ReactNode;
   rows?: number;
   cols?: number;
+  placeholder?: string;
+  refValue?: string;
 }
 
 const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ children, ...rest }: TextareaProps, ref): ReactElement => {
+  ({ children, refValue = '', ...rest }: TextareaProps, ref): ReactElement => {
+    // TODO: current에 대한 타입 지정
+    useEffect(() => {
+      if (ref && refValue) {
+        if (ref.current) {
+          ref.current.value = refValue;
+        }
+      }
+    }, []);
+
     return (
       <textarea ref={ref} {...rest}>
         {children}


### PR DESCRIPTION
리액트의 `input`은 렌더링할 때마다 값을 대입하는 구조라고 합니다. 때문에 `value` 값에 특정한 값을 집어넣게 되면 리렌더링 될 때마다 해당 값으로 초기화되어버려서 입력을 할 수 없는 상황이 발생합니다. 때문에 `input`에서 `value` 값을 제거하면서도 초기의 값을 설정해 줄 수 있는 방법이 필요했습니다.

https://ko.reactjs.org/docs/refs-and-the-dom.html#callback-refs
때문에 공식문서의 내용과 용재님의 조언을 바탕으로 useEffect 안에서 첫 렌더링시 `current.value`의 값을 초기화 시켜주도록 작성했습니다.

current에 대한 타입도 지정해주고 싶었는데 타입에러가 지워지지 않아서 일단 완벽하게 고치지는 못하였습니다.
여러 삽질을 하면서 알게 된 점은 Ref의 타입이 한 개가 아니라는 점이었습니다.
https://driip.me/7126d5d5-1937-44a8-98ed-f9065a7c35b5
해당 글의 내용이 가장 좋은 것 같지만, 솔직히 저는 완벽하게 이해하지 못하였습니다. 타입스크립트에 대한 능숙도가 부족하다보니 항상 타입 설정에 애를 먹는 것 같습니다. 해당 타입을 지정하실 수 있는 분이 계시다면 수정 부탁드립니다!

기존의 `input`, `textarea`는 그대로 사용하시되, 초기값을 지정하고 싶으시다면 `refValue`값을 추가하시면 됩니다.

@minho-jang  @dididy 