### PR TITLE
팀 생성/수정 모달 로직 수정

### DIFF
--- a/FE/components/organisms/TeamStatusCard/TeamStatusCard.tsx
+++ b/FE/components/organisms/TeamStatusCard/TeamStatusCard.tsx
@@ -1,7 +1,7 @@
 import { ReactElement } from 'react';
 import styled from 'styled-components';
 import { Text, Icon } from '@atoms';
-import { Tag, ProfileImage, Button } from '@molecules';
+import { Tag, ProfileImage } from '@molecules';
 import { useAuthState } from '@store';
 import { Team } from '@utils/type';
 
@@ -97,9 +97,7 @@ export default function TeamStatusCard({
   onClickTeamManage,
 }: TeamStatusCard): ReactElement {
   const { user } = useAuthState();
-
-  // TODO: 현재 사용자가 현재 이 팀의 리더인지?
-  const currentUserIsLeader = true;
+  const currentUserIsLeader = user.id === team.leaderId;
 
   return (
     <Wrapper isComplete={team.completeYN !== 0}>
@@ -114,7 +112,7 @@ export default function TeamStatusCard({
           <div className="profiles">
             {team.teamMembers.map((item) => (
               <div className="profile" key={item.id}>
-                <ProfileImage size={80} src={item.profileSrc} />
+                <ProfileImage size={80} src={item.img ? item.img : undefined} />
                 {item.id === team.leaderId ? (
                   <Text text={item.name + '(팀장)'} />
                 ) : (

--- a/FE/repository/baseRepository.ts
+++ b/FE/repository/baseRepository.ts
@@ -31,28 +31,28 @@ export const getUserListByNameContains = async (param: string) => {
   return new Promise<MemberOption[]>((resolve) => {
     const dummy = [
       {
-        profileSrc: '/profile.png',
+        img: '/profile.png',
         name: '이용재',
         leader: true,
         id: 1,
         email: 'lee@naver.com',
       },
       {
-        profileSrc: '/profile.png',
+        img: '/profile.png',
         name: '장동균',
         leader: false,
         id: 2,
         email: 'jang@gmail.com',
       },
       {
-        profileSrc: '/profile.png',
+        img: '/profile.png',
         name: '장민호',
         leader: false,
         id: 3,
         email: 'minho9301@naver.com',
       },
       {
-        profileSrc: '/profile.png',
+        img: '/profile.png',
         name: '강승현',
         leader: true,
         id: 4,
@@ -173,22 +173,20 @@ export const getTeams = async (
         completeYN: 0,
         nowNumber: 2,
         maxNumber: 3,
-        leaderId: 1,
+        leaderId: 19,
         trackName: '웹 기술',
         teamMembers: [
           {
-            id: 1,
-            name: '안석현',
-            img: 'default',
+            id: 19,
+            name: '장민호',
+            img: '/profile.png',
             email: 'naannaan@naver.com',
-            profileSrc: '/profile.png',
           },
           {
             id: 3,
             name: '박싸피',
             img: null,
             email: 'parkssafy@naver.com',
-            profileSrc: '/profile.png',
           },
         ],
         skills: [
@@ -225,14 +223,12 @@ export const getTeams = async (
             name: '김싸피',
             img: null,
             email: 'kimssafy@naver.com',
-            profileSrc: '/profile.png',
           },
           {
             id: 4,
             name: '강싸피',
             img: null,
             email: 'kangssafy@naver.com',
-            profileSrc: '/profile.png',
           },
         ],
         skills: [
@@ -255,7 +251,6 @@ export const getTeams = async (
         ],
       },
     ];
-
 
     resolve(dummy);
   });

--- a/FE/utils/type.ts
+++ b/FE/utils/type.ts
@@ -1,11 +1,11 @@
-import { OptionsType, OptionTypeBase } from 'react-select';
+import { OptionTypeBase } from 'react-select';
 import { DateTime } from 'luxon';
 
 export interface Member {
   id: number;
   name: string;
   email: string;
-  profileSrc: string;
+  img: string | null | undefined;
 }
 
 export interface Skill {


### PR DESCRIPTION
> Resolve [#S05P13A202-262](https://jira.ssafy.com/browse/S05P13A202-262)

- 팀 수정 모달에서 팀장 수정 가능
- 프로필 이미지 src 속성 지정
- 현재 리더인지 확인하는 로직 추가
- profileSrc 대신 img 사용

[배포된 사이트](https://deploy-preview-116--nifty-jepsen-f8bdc1.netlify.app/team) 들어가서 minho@naver.com/minho로 로그인하고 팀현황 들어가면

제가 팀장인 카드만 수정하는 아이콘이 뜹니다. 인원추가 및 팀장 수정 가능하고, 저장은 API 호출 직전에 로그를 찍고, API 완성하면 연동하겠습니다. 