### PR TITLE
채팅방 다른 채팅방에 접속시 이전 메시지가 표시되는 이슈를 해결한다

### DIFF
--- a/FE/components/organisms/ChatRoom/ChatRoom.tsx
+++ b/FE/components/organisms/ChatRoom/ChatRoom.tsx
@@ -51,6 +51,7 @@ export default function ChatRoom({
   } = useAuthState();
 
   const chatBoxRef: any = useRef<HTMLInputElement>(null);
+  const messageListRef = useRef();
 
   const handleScrollToEnd = () => {
     chatBoxRef.current.scrollTo({
@@ -60,11 +61,15 @@ export default function ChatRoom({
     });
   };
 
+  useEffect(() => {
+    messageListRef.current = messageList;
+  });
+
   // TODO: DateTime.fromISO(time).toRelative()를 위해 60초마다 리렌더링이 일어나도록 강제.. 근데 좋은 코드인지는 모르겠음 추후 리펙토링
   useEffect(() => {
     const interval = setInterval(() => {
-      setMessageList([...messageList]);
-    }, 60000);
+      setMessageList([...messageListRef.current]);
+    }, 2000);
 
     return () => clearInterval(interval);
   }, []);


### PR DESCRIPTION
> resolve [#S05P13A202-284](https://jira.ssafy.com/browse/S05P13A202-284)

* useEffect이 클로저로 구현되어 있고 deps가 빈배열이라.. 스코프에 머문 값이 덮어씌어지는
이슈를 찾아서 해결