### PR TITLE
 fix: 팀 구성 가능여부 Response Model 변경, User Track 수정 로직 변경

### DIFF
--- a/BE/teamgu/src/main/java/com/teamgu/api/controller/TeamController.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/controller/TeamController.java
@@ -20,6 +20,7 @@ import com.teamgu.api.dto.req.TeamIsCreateReqDto;
 import com.teamgu.api.dto.req.TeamMemberReqDto;
 import com.teamgu.api.dto.res.BasicResponse;
 import com.teamgu.api.dto.res.CommonResponse;
+import com.teamgu.api.dto.res.TeamIsCreateResDto;
 import com.teamgu.api.dto.res.TeamListResDto;
 import com.teamgu.api.service.TeamServiceImpl;
 
@@ -42,12 +43,9 @@ public class TeamController {
 		Long userId = teamIsCreateReqDto.getUserId();
 		int projectCode =teamIsCreateReqDto.getProject().getCode();
 		
-		if(teamService.checkTeamBuilding(userId, projectCode)) {
-			
-			return ResponseEntity.ok().build();
-		}
-		
-		return ResponseEntity.badRequest().build();
+		TeamIsCreateResDto teamIsCreateResDto = teamService.checkTeamBuilding(userId, projectCode);
+
+		return ResponseEntity.ok(new CommonResponse<TeamIsCreateResDto>(teamIsCreateResDto));
 	}
 
 	// 추후 필터 완성시 삭제될 메서드
@@ -125,26 +123,6 @@ public class TeamController {
 		return ResponseEntity.ok(new CommonResponse<TeamListResDto>(team));
 	}
 
-	@ApiOperation(value = "팀장 변경하기")
-	@PutMapping("/member")
-	public ResponseEntity<? extends BasicResponse> changeTeamLeader(@RequestBody TeamMemberReqDto teamMemberReqDto) {
-
-		Long teamId = teamMemberReqDto.getTeamId();
-		Long userId = teamMemberReqDto.getUserId();
-
-		List<Long> ids = teamService.getTeamMemberIdbyTeamId(teamId);
-
-		for (Long id : ids) {
-			if (userId == id) { // 존재하는 멤버일 경우
-				teamService.changeTeamLeader(teamMemberReqDto);
-				TeamListResDto team = teamService.getTeamInfobyTeamId(teamId);
-				return ResponseEntity.ok(new CommonResponse<TeamListResDto>(team));
-			}
-		}
-
-		return ResponseEntity.badRequest().build();
-	}
-
 	@ApiOperation(value = "팀나가기")
 	@PutMapping("/exitTeam")
 	public ResponseEntity<? extends BasicResponse> exitTeam(@RequestBody TeamMemberReqDto teamMemberReqDto) {
@@ -194,7 +172,6 @@ public class TeamController {
 		return ResponseEntity.badRequest().build();
 	}
 	
-//
 //	@ApiOperation(value = "팀 구성 완료하기")
 //	@GetMapping("/complete/{teamId}")
 //	public ResponseEntity<? extends BasicResponse> completeTeamBuilding(@PathVariable Long teamId) {
@@ -204,4 +181,24 @@ public class TeamController {
 //		return ResponseEntity.ok(new CommonResponse<TeamListResDto>(team));
 //	}
 
+//	@ApiOperation(value = "팀장 변경하기")
+//	@PutMapping("/member")
+//	public ResponseEntity<? extends BasicResponse> changeTeamLeader(@RequestBody TeamMemberReqDto teamMemberReqDto) {
+//
+//		Long teamId = teamMemberReqDto.getTeamId();
+//		Long userId = teamMemberReqDto.getUserId();
+//
+//		List<Long> ids = teamService.getTeamMemberIdbyTeamId(teamId);
+//
+//		for (Long id : ids) {
+//			if (userId == id) { // 존재하는 멤버일 경우
+//				teamService.changeTeamLeader(teamMemberReqDto);
+//				TeamListResDto team = teamService.getTeamInfobyTeamId(teamId);
+//				return ResponseEntity.ok(new CommonResponse<TeamListResDto>(team));
+//			}
+//		}
+//
+//		return ResponseEntity.badRequest().build();
+//	}
+	
 }

--- a/BE/teamgu/src/main/java/com/teamgu/api/controller/UserController.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/controller/UserController.java
@@ -16,7 +16,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.teamgu.api.dto.req.PasswordReqDto;
 import com.teamgu.api.dto.req.UserInfoReqDto;
+import com.teamgu.api.dto.res.BasicResponse;
+import com.teamgu.api.dto.res.CommonResponse;
 import com.teamgu.api.dto.res.UserInfoAwardResDto;
 import com.teamgu.api.dto.res.UserInfoProjectResDto;
 import com.teamgu.api.dto.res.UserInfoResDto;
@@ -35,13 +38,13 @@ public class UserController {
 	@Autowired
 	UserServiceImpl userService;
 
-//	@PostMapping("/password")
-//	@ApiOperation(value = "비밀번호 변경", notes = "비밀번호를 변경한다.")
-//	public ResponseEntity<BaseResDto> setPassword(
-//			@RequestBody @ApiParam(value = "비밀번호", required = true) PasswordReqDto password) {
-//		userService.setPassward(password);
-//		return ResponseEntity.ok(new BaseResDto(200, "Success"));
-//	}
+	@PutMapping("/password")
+	@ApiOperation(value = "비밀번호 변경", notes = "비밀번호를 변경한다.")
+	public ResponseEntity<? extends BasicResponse> setPassword(
+			@RequestBody @ApiParam(value = "비밀번호", required = true) PasswordReqDto password) {
+		userService.setPassward(password);
+		return ResponseEntity.ok(new CommonResponse<String>("비밀번호 변경 완료"));
+	}
 
 	@ApiOperation(value = "사용자 상세정보 조회", notes = "마이페이지에서 사용자 상세정보를 조회한다.")
 	@GetMapping("/userInfo/{userId}")

--- a/BE/teamgu/src/main/java/com/teamgu/api/dto/res/TeamIsCreateResDto.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/dto/res/TeamIsCreateResDto.java
@@ -1,0 +1,26 @@
+package com.teamgu.api.dto.res;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@ApiModel(description = "팀 구성 가능 여부 응답 모델")
+public class TeamIsCreateResDto {
+		
+	@ApiModelProperty(name = "팀 보유 여부", example="False")
+	boolean hasTeam;
+	
+	@ApiModelProperty(name = "팀 보유 시 해당 팀 정보")
+	TeamListResDto team;
+
+	public TeamIsCreateResDto(boolean hasTeam, TeamListResDto team) {
+		this.hasTeam = hasTeam;
+		this.team = team;
+	}
+	
+}

--- a/BE/teamgu/src/main/java/com/teamgu/api/service/TeamService.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/service/TeamService.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.teamgu.api.dto.req.TeamFilterReqDto;
 import com.teamgu.api.dto.req.TeamMemberReqDto;
+import com.teamgu.api.dto.res.TeamIsCreateResDto;
 import com.teamgu.api.dto.res.TeamListResDto;
 
 public interface TeamService {
@@ -45,6 +46,6 @@ public interface TeamService {
 	boolean checkTeamBuilding(Long userId, String trackName);
 
 	// Check Team Building
-	boolean checkTeamBuilding(Long userId, int projectCode);
+	TeamIsCreateResDto checkTeamBuilding(Long userId, int projectCode);
 	
 }

--- a/BE/teamgu/src/main/java/com/teamgu/api/service/TeamServiceImpl.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/service/TeamServiceImpl.java
@@ -1,5 +1,6 @@
 package com.teamgu.api.service;
 
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -10,6 +11,7 @@ import com.teamgu.api.dto.req.TeamFilterReqDto;
 import com.teamgu.api.dto.req.TeamMemberReqDto;
 import com.teamgu.api.dto.req.TrackReqDto;
 import com.teamgu.api.dto.res.SkillResDto;
+import com.teamgu.api.dto.res.TeamIsCreateResDto;
 import com.teamgu.api.dto.res.TeamListResDto;
 import com.teamgu.api.dto.res.TeamMemberInfoResDto;
 import com.teamgu.database.entity.Mapping;
@@ -327,17 +329,57 @@ public class TeamServiceImpl implements TeamService {
 		
 		return teamRepositorySupport.getTeamMemberIdbyTeamId(teamId);
 	}
+	
+	/*
+	 * userId와 trackName을 이용한 팀빌딩 체크
+	 */	
+	
 	@Override
 	public boolean checkTeamBuilding(Long userId, String trackName) {
 		// TODO Auto-generated method stub
 		return teamRepositorySupport.checkTeamBuilding(userId, trackName);
 	}
 
+	/*
+	 * userId와 projectCode을 이용한 팀빌딩 체크
+	 */	
+	
 	@Override
-	public boolean checkTeamBuilding(Long userId, int projectCode) {
+	public TeamIsCreateResDto checkTeamBuilding(Long userId, int projectCode) {
 		// TODO Auto-generated method stub
-		return teamRepositorySupport.checkTeamBuilding(userId, projectCode);
+		
+		List<BigInteger> teamIds = teamRepositorySupport.checkTeamBuilding(userId, projectCode);
+		int size = teamIds.size();
+		
+		TeamIsCreateResDto teamIsCreateResDto = new TeamIsCreateResDto();
+		if(size == 0) {
+			
+			teamIsCreateResDto.setHasTeam(false);
+			return teamIsCreateResDto;
+			
+		}
+		else {
+			Long teamId = teamIds.get(0).longValue();
+			System.out.println(teamId + " / " + teamId.getClass());
+			System.out.println("TeamServiceImple : 팀이 있음");
+			teamIsCreateResDto.setHasTeam(true);
+			teamIsCreateResDto.setTeam(getTeamInfobyTeamId(teamId));
+			return teamIsCreateResDto;
+		}
+		
 	}
 
 
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
 }

--- a/BE/teamgu/src/main/java/com/teamgu/api/service/UserServiceImpl.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/service/UserServiceImpl.java
@@ -198,6 +198,8 @@ public class UserServiceImpl implements UserService {
 
 		Long userId = userInfoReqDto.getId();			
 		User user = getUserById(userId).get();
+		int stageCode = (user.getStudentNumber().charAt(0) - '0') * 10
+				+ user.getStudentNumber().charAt(1) - '0' + 100;
 
 		// Wish Position, Introduce 수정
 		userRepositorySupport.updateUserDetailInfo(userInfoReqDto);
@@ -230,11 +232,8 @@ public class UserServiceImpl implements UserService {
 		for(int i = 0; i<updateWishTracksSize; i++) {
 			if(updateWishTracksCheck[i]) continue;
 			int trackCode = codeDetailRepositorySupport.findTtrackCode(updateWishTracks.get(i));
-			WishTrack wishTrack = new WishTrack();
-			Mapping mapping = mappingRepositorySupport.selectMapping(trackCode);
-			//Mapping mapping = mappingRepository.findByTrackCode(trackCode).get();
+			Mapping mapping = mappingRepositorySupport.selectMapping(trackCode, stageCode);
 			wishTrackRepositorySupport.insertWishTrack(userId, mapping.getId());
-			//wishTrackRepository.save(wishTrack);
 			
 		}
 		
@@ -242,7 +241,9 @@ public class UserServiceImpl implements UserService {
 		for(int i = 0; i<originWishTracksSize; i++) {
 			if(originWishTracksCheck[i]) continue;
 			int trackCode = codeDetailRepositorySupport.findTtrackCode(originWishTracks.get(i));
-			userRepositorySupport.deleteUserWishTrack(userId, trackCode);
+			Mapping mapping = mappingRepositorySupport.selectMapping(trackCode, stageCode);
+
+			userRepositorySupport.deleteUserWishTrack(userId, mapping.getId());
 		}
 		
 		
@@ -275,7 +276,6 @@ public class UserServiceImpl implements UserService {
 			if(updateSkillsCheck[i]) continue;
 			int skillCode = codeDetailRepositorySupport.findSkillCode(updateSkills.get(i));
 			userSkillRepositorySupport.insertSkiil(userId, skillCode);
-			//skillRepository.save(skill);
 		}
 		
 		// originSkillsCheck가 false 이면 삭제된 Skill
@@ -284,42 +284,6 @@ public class UserServiceImpl implements UserService {
 			int skillCode = codeDetailRepositorySupport.findSkillCode(originSkills.get(i));
 			userRepositorySupport.deleteUserSkill(userId, skillCode);
 		}
-		
-		
-//		User user = getUserByEmail(userInfoReq.getEmail()).get();
-//		user.setStudentNumber(userInfoReq.getStudentNumber());
-//		user.setWishPositionCode(userInfoReq.getWishPosition());
-//		System.out.println(userInfoReq.getStudentNumber().substring(1, 2) + "기");
-//		// 학번 입력 받아서 project
-//		int stageCode = codeDetailRepositorySupport.finStageCode(userInfoReq.getStudentNumber().substring(1, 2) + "기");
-//
-//		int projegtCode = projectDetailRepositorySuport.findProjectCode();
-//
-//		// 선호 트랙 저장
-//		List<String> wishTracks = userInfoReq.getWishTrack();
-//		WishTrack wishTrack = new WishTrack();
-//		for (String name : wishTracks) {
-//			wishTrack.setUser(user);
-//			// string to int
-//			int code = codeDetailRepositorySupport.findTtrackCode(name);
-//			wishTrack.setMapping(
-//					Mapping.builder().stageCode(stageCode).projectCode(projegtCode).trackCode(code).build());
-//			wishTrackRepository.save(wishTrack);
-//		}
-//
-//		user.setIntroduce(userInfoReq.getIntroduce());
-//
-//		// 기술 스택 저장
-//		List<String> skills = userInfoReq.getSkill();
-//		Skill skill = new Skill();
-//		for (String name : skills) {
-//			int code = codeDetailRepositorySupport.findSkillCode(name);
-//			skill.setUser(user);
-//			skill.setSkillCode(code);
-//			skillRepository.save(skill);
-//		}
-//
-//		userRepository.save(user);
 	}
 
 	/**

--- a/BE/teamgu/src/main/java/com/teamgu/database/repository/TeamRepositorySupport.java
+++ b/BE/teamgu/src/main/java/com/teamgu/database/repository/TeamRepositorySupport.java
@@ -1,5 +1,6 @@
 package com.teamgu.database.repository;
 
+import java.math.BigInteger;
 import java.util.List;
 import java.util.Optional;
 
@@ -234,10 +235,10 @@ public class TeamRepositorySupport {
 	}
 	
 	// Team 생성 가능 여부 체크
-	public boolean checkTeamBuilding(Long userId, int projectCode) {
+	public List<BigInteger> checkTeamBuilding(Long userId, int projectCode) {
 		EntityManager em = emf.createEntityManager();
 		
-		String jpql = "select user_id from user_team where team_id in \r\n" + 
+		String jpql = "select team_id from user_team where team_id in \r\n" + 
 				"(select id from team where team.mapping_id in \r\n" + 
 				"(select mapping.id from mapping where mapping.project_code = ?1))" +
 				" and user_id = ?2";
@@ -245,15 +246,9 @@ public class TeamRepositorySupport {
 		.setParameter(1, projectCode)
 		.setParameter(2, userId)
 		;
-		List<Long> chk = query.getResultList();
-		int size = chk.size();
-		em.close();
-		if(size == 0) {
-			return true;
-		}
-		else {
-			return false;
-		}
+		List<BigInteger> result = query.getResultList();
+		
+		return result;
 
 	}
 	

--- a/BE/teamgu/src/main/java/com/teamgu/database/repository/UserRepositorySupport.java
+++ b/BE/teamgu/src/main/java/com/teamgu/database/repository/UserRepositorySupport.java
@@ -172,12 +172,7 @@ public class UserRepositorySupport {
 	
 	// User Wish Track 삭제
 	@Transactional
-	public void deleteUserWishTrack(Long userId, int trackCode) {
-		JPAQuery<Long> mappingId = 
-				jpaQueryFactory
-				.select(qMapping.id)
-				.from(qMapping)
-				.where(qMapping.trackCode.eq(trackCode));
+	public void deleteUserWishTrack(Long userId, Long mappingId) {
 
 		jpaQueryFactory
 				.delete(qWishTrack)


### PR DESCRIPTION
1. 팀 구성 가능 여부 Response Model 변경
 - 기존 : 팀 구성을 하고 있지 않으면 200 / 아니면 400으로 처리
 - 수정 : 팀 구성을 하고 있지 않으면 false, 하고 있으면 true와 팀 정보 반환

2. 기존 user track 수정 시 trackName으로만 조회하여 업데이트하는 문제로 인하여 stage Issue 발생
 - User Student Number 기반 stageCode와 함께 조회하여 업데이트