### PR TITLE
이미지에 대한 프리뷰와 크롭을 가능하게 합니다

### DIFF
--- a/FE/components/atoms/Input/Input.tsx
+++ b/FE/components/atoms/Input/Input.tsx
@@ -24,6 +24,7 @@ interface InputProps {
   readOnly?: boolean;
   value?: string;
   refValue?: string;
+  accept?: string;
 }
 
 const Wrapper = styled.div<{
@@ -74,6 +75,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
       readOnly = false,
       value,
       refValue = '',
+      accept = '',
     }: InputProps,
     ref,
   ): ReactElement => {
@@ -108,6 +110,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
           readOnly={readOnly}
           value={value}
           onKeyDown={onKeyDown}
+          accept={accept}
         />
         {error?.split('/')[0] !== '' && <div>{error?.split('/')[0]}</div>}
       </Wrapper>

--- a/FE/components/organisms/UserDetail/MyDetail/Modal/SetImageModal.tsx
+++ b/FE/components/organisms/UserDetail/MyDetail/Modal/SetImageModal.tsx
@@ -146,11 +146,11 @@ export default function RenderCropper({
           />
         </div>
 
-        <Button title="Clear" func={onClear} width="5vw" />
+        <Button title="Clear" func={onClear} width="80px" />
 
-        <Button title="Choose" func={triggerFileSelectPopup} width="5vw" />
+        <Button title="Choose" func={triggerFileSelectPopup} width="80px" />
 
-        <Button title="Upload" func={onUpload} width="5vw" />
+        <Button title="Upload" func={onUpload} width="80px" />
       </div>
     </Wrapper>
   );

--- a/FE/components/organisms/UserDetail/MyDetail/Modal/SetImageModal.tsx
+++ b/FE/components/organisms/UserDetail/MyDetail/Modal/SetImageModal.tsx
@@ -1,0 +1,157 @@
+import React, { useState, useRef } from 'react';
+import styled from 'styled-components';
+import Cropper from 'react-easy-crop';
+import { Point, Area } from 'react-easy-crop/types';
+import Slider from '@material-ui/core/Slider';
+import { Icon, Input } from '@atoms';
+import { Button } from '@molecules';
+import getCroppedImg from '@utils/cropImage';
+import { dataURLtoFile } from '@utils/dataURLtoFile';
+
+const Wrapper = styled.div`
+  width: 50vw;
+  height: calc(100vh - 150px);
+  position: relative;
+  background-color: rgba(0, 0, 0, 0.5);
+
+  i {
+    cursor: pointer;
+    position: absolute;
+    top: 5%;
+    right: 5%;
+    z-index: 100;
+  }
+
+  .container-cropper {
+    height: 90%;
+    padding: 10px;
+  }
+
+  .cropper {
+    height: 90%;
+    position: relative;
+  }
+
+  .slider {
+    height: 10%;
+    display: flex;
+    align-items: center;
+    margin: auto;
+    width: 60%;
+  }
+
+  .container-buttons {
+    border: 1px solid #f5f5f5;
+    height: 10%;
+    display: flex;
+    align-items: center;
+    justify-content: space-around;
+    background-color: white;
+    .none {
+      display: none;
+    }
+  }
+`;
+
+export default function RenderCropper({
+  image,
+  setImage,
+  setSubmitImage,
+  changeImageMode,
+}: any) {
+  const inputRef = useRef();
+
+  const triggerFileSelectPopup = () => inputRef?.current?.click();
+
+  const [croppedArea, setCroppedArea] = useState<Area>(Object);
+  const [crop, setCrop] = useState<Point>({ x: 0, y: 0 });
+  const [zoom, setZoom] = useState(1);
+
+  const onCropComplete = (
+    croppedAreaPercentage: Area,
+    croppedAreaPixels: Area,
+  ) => setCroppedArea(croppedAreaPixels);
+
+  const onSelectFile = (e: Event & { target: HTMLInputElement }) => {
+    if (e.target.files && e.target.files.length > 0) {
+      const reader = new FileReader();
+      reader.readAsDataURL(e.target.files[0]);
+      reader.addEventListener('load', () => {
+        setImage(reader.result);
+      });
+    }
+  };
+
+  const onClear = () => {
+    setImage('/profile.png');
+  };
+
+  // To upload the edited image
+  const onUpload = async () => {
+    const canvas = await getCroppedImg(image, croppedArea);
+    const canvasDataUrl = canvas.toDataURL('image/jpeg');
+    setImage(canvasDataUrl);
+    const convertedUrlToFile = dataURLtoFile(
+      canvasDataUrl,
+      'cropped-image.jpeg',
+    );
+    // 실제 제출하는 파일은 아래 파일이 될 것이다.
+    setSubmitImage(convertedUrlToFile);
+    changeImageMode();
+  };
+
+  return (
+    <Wrapper>
+      <div>
+        <Icon iconName="clear" color="black" func={changeImageMode} />
+      </div>
+      <div className="container-cropper">
+        {image ? (
+          <>
+            <div className="cropper">
+              <Cropper
+                image={image}
+                crop={crop}
+                zoom={zoom}
+                aspect={1}
+                cropShape="round"
+                showGrid={false}
+                onCropChange={setCrop}
+                onZoomChange={setZoom}
+                onCropComplete={onCropComplete}
+              />
+            </div>
+
+            <div className="slider">
+              <Slider
+                min={1}
+                max={3}
+                step={0.1}
+                value={zoom}
+                onChange={(e, zoom) => setZoom(zoom)}
+                color="secondary"
+              />
+            </div>
+          </>
+        ) : null}
+      </div>
+
+      <div className="container-buttons">
+        <div className="none">
+          <Input
+            type="file"
+            accept="image/*"
+            ref={inputRef}
+            func={onSelectFile}
+          />
+        </div>
+
+        <Button title="Clear" func={onClear} width="5vw" />
+
+        <Button title="Choose" func={triggerFileSelectPopup} width="5vw" />
+
+        <Button title="Upload" func={onUpload} width="5vw" />
+      </div>
+    </Wrapper>
+  );
+}

--- a/FE/components/organisms/UserDetail/MyDetail/MyDetail.tsx
+++ b/FE/components/organisms/UserDetail/MyDetail/MyDetail.tsx
@@ -97,6 +97,8 @@ const Portrait = styled.div`
   img {
     width: 70%;
     margin-top: 15vh;
+    border: 2px solid gray;
+    border-radius: 50%;
   }
 `;
 

--- a/FE/components/organisms/UserDetail/MyDetail/MyDetailEdit.tsx
+++ b/FE/components/organisms/UserDetail/MyDetail/MyDetailEdit.tsx
@@ -22,6 +22,8 @@ import {
 } from '@repository/userprofile';
 import { MODALS } from '@utils/constants';
 import { Skill } from '@utils/type';
+import SetImageModal from '../MyDetail/Modal/SetImageModal';
+import { ModalWrapper } from 'components/organisms';
 
 const Wrapper = styled.div`
   border: 1px solid rgba(0, 0, 0, 0.2);
@@ -387,19 +389,34 @@ export default function MyDetailEdit({ changeEditMode }: any): ReactElement {
   const { user } = useAuthState();
   const dispatch = useAppDispatch();
 
-  // const [image, setImage] = useState('');
+  const [image, setImage] = useState(
+    user.img === 'null.null' ? '/profile.png' : user.img,
+  );
+
+  // 실제 제출하게될 이미지 파일
+  const [submitImage, setSubmitImage] = useState<File>();
+
   const [useableSkills, setUseableSkills] = useState<string[]>(user.skills);
   const [introduce, setIntroduce] = useState(user.introduce);
   // TODO 이거 배열로 들어올지 아니면 문자열 하나로 들어올지 확실히 해야함.
   const [track, setTrack] = useState<string>(user.wishTrack[0]);
   const [position, setPosition] = useState<string>(user.wishPositionCode);
+  const [showCroppedArea, setShowCroppedArea] = useState(false);
+
+  const handleImage = (image: string) => {
+    setImage(image);
+  };
+
+  const handleSubmitImage = (image: File) => {
+    setSubmitImage(image);
+  };
+
+  const changeImageMode = () => {
+    setShowCroppedArea(!showCroppedArea);
+  };
 
   const handleIntroduce = (e: Event & { target: HTMLTextAreaElement }) => {
     setIntroduce(e.target.value);
-  };
-
-  const changeImage = (e: EventTarget & { target: HTMLInputElement }) => {
-    setImage(e.target.files[0]);
   };
 
   const changeUseableSkills = (value: { id: number; name: string }[]) => {
@@ -485,6 +502,16 @@ export default function MyDetailEdit({ changeEditMode }: any): ReactElement {
 
   return (
     <Wrapper>
+      {showCroppedArea && (
+        <ModalWrapper modalName="setImage">
+          <SetImageModal
+            image={image}
+            setImage={handleImage}
+            setSubmitImage={handleSubmitImage}
+            changeImageMode={changeImageMode}
+          />
+        </ModalWrapper>
+      )}
       <Icons>
         <Icon iconName="clear" color="black" func={changeEditMode} />
       </Icons>
@@ -563,12 +590,8 @@ export default function MyDetailEdit({ changeEditMode }: any): ReactElement {
             </div>
           </Manifesto>
           <Portrait>
-            <img
-              className="default-image"
-              alt="프로필이미지"
-              src="/profile.png"
-            />
-            <Input type="file" func={changeImage} name="img" />
+            <img className="default-image" alt="프로필이미지" src={image} />
+            <Icon iconName="photo_camera" func={changeImageMode} />
           </Portrait>
         </Introduction>
         <div className="buttonRight">

--- a/FE/components/organisms/UserDetail/MyDetail/MyDetailEdit.tsx
+++ b/FE/components/organisms/UserDetail/MyDetail/MyDetailEdit.tsx
@@ -134,6 +134,8 @@ const Portrait = styled.div`
   img {
     width: 70%;
     margin-top: 15vh;
+    border: 2px solid gray;
+    border-radius: 50%;
   }
 `;
 

--- a/FE/components/organisms/UserDetail/MyDetail/MyDetailEdit.tsx
+++ b/FE/components/organisms/UserDetail/MyDetail/MyDetailEdit.tsx
@@ -1,12 +1,13 @@
-import { ReactElement, SyntheticEvent, useState, useRef } from 'react';
+import { ReactElement, SyntheticEvent, useState } from 'react';
 import styled from 'styled-components';
-import { Icon, Input, Textarea, Text } from '@atoms';
+import { Icon, Textarea, Text } from '@atoms';
 import {
   Button,
   SimpleSelect,
   SkillSelectAutoComplete,
   Label,
 } from '@molecules';
+import { ModalWrapper } from '@organisms';
 import {
   useAuthState,
   useAppDispatch,
@@ -23,7 +24,6 @@ import {
 import { MODALS } from '@utils/constants';
 import { Skill } from '@utils/type';
 import SetImageModal from '../MyDetail/Modal/SetImageModal';
-import { ModalWrapper } from 'components/organisms';
 
 const Wrapper = styled.div`
   border: 1px solid rgba(0, 0, 0, 0.2);

--- a/FE/package.json
+++ b/FE/package.json
@@ -12,6 +12,7 @@
     "build-storybook": "build-storybook -c .storybook watch-css -s ./public"
   },
   "dependencies": {
+    "@material-ui/core": "^4.12.3",
     "@reduxjs/toolkit": "^1.6.0",
     "@types/react-select": "^4.0.17",
     "axios": "^0.21.1",
@@ -21,6 +22,7 @@
     "openvidu-browser": "2.19.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",
+    "react-easy-crop": "^3.5.2",
     "react-linkify": "^1.0.0-alpha",
     "react-redux": "^7.2.4",
     "react-select": "^4.3.1",

--- a/FE/utils/cropImage.ts
+++ b/FE/utils/cropImage.ts
@@ -1,0 +1,67 @@
+/**
+ * This function was adapted from the one in the ReadMe of https://github.com/DominicTobias/react-image-crop
+ * @param {File} imageSrc - Image File url
+ * @param {Object} pixelCrop - pixelCrop Object provided by react-easy-crop
+ * @param {number} rotation - optional rotation parameter
+ */
+import { Area } from 'react-easy-crop/types';
+
+const createImage = (url: string) =>
+  new Promise((resolve, reject) => {
+    const image = new Image();
+    image.addEventListener('load', () => resolve(image));
+    image.addEventListener('error', (error) => reject(error));
+    image.setAttribute('crossOrigin', 'anonymous'); // needed to avoid cross-origin issues on CodeSandbox
+    image.src = url;
+  });
+
+function getRadianAngle(degreeValue: number) {
+  return (degreeValue * Math.PI) / 180;
+}
+
+export default async function getCroppedImg(
+  imageSrc: Area,
+  pixelCrop: Area,
+  rotation = 0,
+) {
+  const image: HTMLImageElement = await createImage(imageSrc);
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d');
+
+  const maxSize = Math.max(image.width, image.height);
+  const safeArea = 2 * ((maxSize / 2) * Math.sqrt(2));
+
+  // set each dimensions to double largest dimension to allow for a safe area for the
+  // image to rotate in without being clipped by canvas context
+  canvas.width = safeArea;
+  canvas.height = safeArea;
+
+  // translate canvas context to a central location on image to allow rotating around the center.
+  ctx?.translate(safeArea / 2, safeArea / 2);
+  ctx?.rotate(getRadianAngle(rotation));
+  ctx?.translate(-safeArea / 2, -safeArea / 2);
+
+  // draw rotated image and store data.
+  ctx?.drawImage(
+    image,
+    safeArea / 2 - image.width * 0.5,
+    safeArea / 2 - image.height * 0.5,
+  );
+
+  const data = ctx?.getImageData(0, 0, safeArea, safeArea);
+
+  // set canvas width to final desired crop size - this will clear existing context
+  canvas.width = pixelCrop.width;
+  canvas.height = pixelCrop.height;
+
+  // paste generated rotate image with correct offsets for x,y crop values.
+  ctx?.putImageData(
+    data,
+    0 - safeArea / 2 + image.width * 0.5 - pixelCrop.x,
+    0 - safeArea / 2 + image.height * 0.5 - pixelCrop.y,
+  );
+
+  // As Base64 string
+  // return canvas.toDataURL("image/jpeg");
+  return canvas;
+}

--- a/FE/utils/dataURLtoFile.ts
+++ b/FE/utils/dataURLtoFile.ts
@@ -1,0 +1,11 @@
+export const dataURLtoFile = (dataurl: string, filename: string) => {
+  const arr = dataurl.split(',');
+  const mime = arr[0].match(/:(.*?);/)[1];
+  const bstr = atob(arr[1]);
+  let n = bstr.length;
+  const u8arr = new Uint8Array(n);
+
+  while (n--) u8arr[n] = bstr.charCodeAt(n);
+
+  return new File([u8arr], filename, { type: mime });
+};

--- a/FE/yarn.lock
+++ b/FE/yarn.lock
@@ -1079,7 +1079,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.12.0", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.12.0", "@babel/runtime@^7.4.4", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.7":
   version "7.14.8"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.8.tgz#7119a56f421018852694290b9f9148097391b446"
   integrity sha512-twj3L8Og5SaCRCErB4x4ajbvBIVV77CGeFglHpeg5WC5FF8TZzBWXtTJ4MqaD9QszLYTtr+IsaAL2rEUevb+eg==
@@ -1567,6 +1567,70 @@
     "@types/node" "*"
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
+
+"@material-ui/core@^4.12.3":
+  version "4.12.3"
+  resolved "https://registry.yarnpkg.com/@material-ui/core/-/core-4.12.3.tgz#80d665caf0f1f034e52355c5450c0e38b099d3ca"
+  integrity sha512-sdpgI/PL56QVsEJldwEe4FFaFTLUqN+rd7sSZiRCdx2E/C7z5yK0y/khAWVBH24tXwto7I1hCzNWfJGZIYJKnw==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@material-ui/styles" "^4.11.4"
+    "@material-ui/system" "^4.12.1"
+    "@material-ui/types" "5.1.0"
+    "@material-ui/utils" "^4.11.2"
+    "@types/react-transition-group" "^4.2.0"
+    clsx "^1.0.4"
+    hoist-non-react-statics "^3.3.2"
+    popper.js "1.16.1-lts"
+    prop-types "^15.7.2"
+    react-is "^16.8.0 || ^17.0.0"
+    react-transition-group "^4.4.0"
+
+"@material-ui/styles@^4.11.4":
+  version "4.11.4"
+  resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.11.4.tgz#eb9dfccfcc2d208243d986457dff025497afa00d"
+  integrity sha512-KNTIZcnj/zprG5LW0Sao7zw+yG3O35pviHzejMdcSGCdWbiO8qzRgOYL8JAxAsWBKOKYwVZxXtHWaB5T2Kvxew==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@emotion/hash" "^0.8.0"
+    "@material-ui/types" "5.1.0"
+    "@material-ui/utils" "^4.11.2"
+    clsx "^1.0.4"
+    csstype "^2.5.2"
+    hoist-non-react-statics "^3.3.2"
+    jss "^10.5.1"
+    jss-plugin-camel-case "^10.5.1"
+    jss-plugin-default-unit "^10.5.1"
+    jss-plugin-global "^10.5.1"
+    jss-plugin-nested "^10.5.1"
+    jss-plugin-props-sort "^10.5.1"
+    jss-plugin-rule-value-function "^10.5.1"
+    jss-plugin-vendor-prefixer "^10.5.1"
+    prop-types "^15.7.2"
+
+"@material-ui/system@^4.12.1":
+  version "4.12.1"
+  resolved "https://registry.yarnpkg.com/@material-ui/system/-/system-4.12.1.tgz#2dd96c243f8c0a331b2bb6d46efd7771a399707c"
+  integrity sha512-lUdzs4q9kEXZGhbN7BptyiS1rLNHe6kG9o8Y307HCvF4sQxbCgpL2qi+gUk+yI8a2DNk48gISEQxoxpgph0xIw==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@material-ui/utils" "^4.11.2"
+    csstype "^2.5.2"
+    prop-types "^15.7.2"
+
+"@material-ui/types@5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@material-ui/types/-/types-5.1.0.tgz#efa1c7a0b0eaa4c7c87ac0390445f0f88b0d88f2"
+  integrity sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==
+
+"@material-ui/utils@^4.11.2":
+  version "4.11.2"
+  resolved "https://registry.yarnpkg.com/@material-ui/utils/-/utils-4.11.2.tgz#f1aefa7e7dff2ebcb97d31de51aecab1bb57540a"
+  integrity sha512-Uul8w38u+PICe2Fg2pDKCaIG7kOyhowZ9vjiC1FsVwPABTW8vPPKfF6OvxRq3IiBaI1faOJmgdvMG7rMJARBhA==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    prop-types "^15.7.2"
+    react-is "^16.8.0 || ^17.0.0"
 
 "@mdx-js/loader@^1.6.22":
   version "1.6.22"
@@ -2813,7 +2877,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-transition-group@*":
+"@types/react-transition-group@*", "@types/react-transition-group@^4.2.0":
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.2.tgz#38890fd9db68bf1f2252b99a942998dc7877c5b3"
   integrity sha512-KibDWL6nshuOJ0fu8ll7QnV/LVTo3PzQ9aCPnRUYPfX7eZohHwLIdNHj7pftanREzHNP4/nJa8oeM73uSiavMQ==
@@ -4454,6 +4518,11 @@ clone-deep@^4.0.1:
     kind-of "^6.0.2"
     shallow-clone "^3.0.0"
 
+clsx@^1.0.4:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
+  integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -4866,6 +4935,14 @@ css-to-react-native@^3.0.0:
     css-color-keywords "^1.0.0"
     postcss-value-parser "^4.0.2"
 
+css-vendor@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/css-vendor/-/css-vendor-2.0.8.tgz#e47f91d3bd3117d49180a3c935e62e3d9f7f449d"
+  integrity sha512-x9Aq0XTInxrkuFeHKbYC7zWY8ai7qJ04Kxd9MnvbC1uO5DagxoHQjm4JvG+vCdXOoFtCjbL2XSZfxmoYa9uQVQ==
+  dependencies:
+    "@babel/runtime" "^7.8.3"
+    is-in-browser "^1.0.2"
+
 css-what@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-5.0.1.tgz#3efa820131f4669a8ac2408f9c32e7c7de9f4cad"
@@ -4921,7 +4998,7 @@ cssstyle@^2.3.0:
   dependencies:
     cssom "~0.3.6"
 
-csstype@^2.5.7:
+csstype@^2.5.2, csstype@^2.5.7:
   version "2.6.17"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.17.tgz#4cf30eb87e1d1a005d8b6510f95292413f6a1c0e"
   integrity sha512-u1wmTI1jJGzCJzWndZo8mk4wnPTZd1eOIYTYvuEyOQGfmDl3TrabCCfKnOC86FZwW/9djqTl933UF/cS425i9A==
@@ -6993,6 +7070,11 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
+hyphenate-style-name@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz#691879af8e220aea5750e8827db4ef62a54e361d"
+  integrity sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ==
+
 iconv-lite@0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -7386,6 +7468,11 @@ is-hexadecimal@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz#cc35c97588da4bd49a8eedd6bc4082d44dcb23a7"
   integrity sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==
+
+is-in-browser@^1.0.2, is-in-browser@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/is-in-browser/-/is-in-browser-1.1.3.tgz#56ff4db683a078c6082eb95dad7dc62e1d04f835"
+  integrity sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU=
 
 is-map@^2.0.2:
   version "2.0.2"
@@ -8246,6 +8333,76 @@ jsonfile@^6.0.1:
     universalify "^2.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
+
+jss-plugin-camel-case@^10.5.1:
+  version "10.7.1"
+  resolved "https://registry.yarnpkg.com/jss-plugin-camel-case/-/jss-plugin-camel-case-10.7.1.tgz#e7f7097cf97e9deec599cef3275e213452318b93"
+  integrity sha512-+ioIyWvmAfgDCWXsQcW1NMnLBvRinOVFkSYJUgewQ6TynOcSj5F1bSU23B7z0p1iqK0PPHIU62xY1iNJD33WGA==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    hyphenate-style-name "^1.0.3"
+    jss "10.7.1"
+
+jss-plugin-default-unit@^10.5.1:
+  version "10.7.1"
+  resolved "https://registry.yarnpkg.com/jss-plugin-default-unit/-/jss-plugin-default-unit-10.7.1.tgz#826270e2ee38d7024a281ac67c30d6944f124786"
+  integrity sha512-tW+dfYVNARBQb/ONzBwd8uyImigyzMiAEDai+AbH5rcHg5h3TtqhAkxx06iuZiT/dZUiFdSKlbe3q9jZGAPIwA==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    jss "10.7.1"
+
+jss-plugin-global@^10.5.1:
+  version "10.7.1"
+  resolved "https://registry.yarnpkg.com/jss-plugin-global/-/jss-plugin-global-10.7.1.tgz#9725c46d662aac2e596a0a8741944c060e2b90a1"
+  integrity sha512-FbxCnu44IkK/bw8X3CwZKmcAnJqjAb9LujlAc/aP0bMSdVa3/MugKQRyeQSu00uGL44feJJDoeXXiHOakBr/Zw==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    jss "10.7.1"
+
+jss-plugin-nested@^10.5.1:
+  version "10.7.1"
+  resolved "https://registry.yarnpkg.com/jss-plugin-nested/-/jss-plugin-nested-10.7.1.tgz#35563a7a710a45307fd6b9742ffada1d72a62eb7"
+  integrity sha512-RNbICk7FlYKaJyv9tkMl7s6FFfeLA3ubNIFKvPqaWtADK0KUaPsPXVYBkAu4x1ItgsWx67xvReMrkcKA0jSXfA==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    jss "10.7.1"
+    tiny-warning "^1.0.2"
+
+jss-plugin-props-sort@^10.5.1:
+  version "10.7.1"
+  resolved "https://registry.yarnpkg.com/jss-plugin-props-sort/-/jss-plugin-props-sort-10.7.1.tgz#1d12b26048541ed3a2ed1b69f7fc231605728362"
+  integrity sha512-eyd5FhA+J0QrpqXxO7YNF/HMSXXl4pB0EmUdY4vSJI4QG22F59vQ6AHtP6fSwhmBdQ98Qd9gjfO+RMxcE39P1A==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    jss "10.7.1"
+
+jss-plugin-rule-value-function@^10.5.1:
+  version "10.7.1"
+  resolved "https://registry.yarnpkg.com/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.7.1.tgz#123eb796eb9982f8efa7a7e362daddd90c0c69fe"
+  integrity sha512-fGAAImlbaHD3fXAHI3ooX6aRESOl5iBt3LjpVjxs9II5u9tzam7pqFUmgTcrip9VpRqYHn8J3gA7kCtm8xKwHg==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    jss "10.7.1"
+    tiny-warning "^1.0.2"
+
+jss-plugin-vendor-prefixer@^10.5.1:
+  version "10.7.1"
+  resolved "https://registry.yarnpkg.com/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.7.1.tgz#217821be2d6dacee31d2d464886760ba7742e19a"
+  integrity sha512-1UHFmBn7hZNsHXTkLLOL8abRl8vi+D1EVzWD4WmLFj55vawHZfnH1oEz6TUf5Y61XHv0smdHabdXds6BgOXe3A==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    css-vendor "^2.0.8"
+    jss "10.7.1"
+
+jss@10.7.1, jss@^10.5.1:
+  version "10.7.1"
+  resolved "https://registry.yarnpkg.com/jss/-/jss-10.7.1.tgz#16d846e1a22fb42e857b99f9c6a0c5a27341c804"
+  integrity sha512-5QN8JSVZR6cxpZNeGfzIjqPEP+ZJwJJfZbXmeABNdxiExyO+eJJDy6WDtqTf8SDKnbL5kZllEpAP71E/Lt7PXg==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    csstype "^3.0.2"
+    is-in-browser "^1.1.3"
+    tiny-warning "^1.0.2"
 
 "jsx-ast-utils@^2.4.1 || ^3.0.0", jsx-ast-utils@^3.1.0:
   version "3.2.0"
@@ -9124,6 +9281,11 @@ normalize-range@^0.1.2:
   resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
   integrity sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=
 
+normalize-wheel@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/normalize-wheel/-/normalize-wheel-1.0.1.tgz#aec886affdb045070d856447df62ecf86146ec45"
+  integrity sha1-rsiGr/2wRQcNhWRH32Ls+GFG7EU=
+
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
@@ -9747,6 +9909,11 @@ popmotion@9.3.6:
     style-value-types "4.1.4"
     tslib "^2.1.0"
 
+popper.js@1.16.1-lts:
+  version "1.16.1-lts"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1-lts.tgz#cf6847b807da3799d80ee3d6d2f90df8a3f50b05"
+  integrity sha512-Kjw8nKRl1m+VrSFCoVGPph93W/qrSO7ZkqPpTf7F4bk/sqcfWK019dWBUpE/fBOsOQY1dks/Bmcbfn1heM/IsA==
+
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
@@ -10212,6 +10379,14 @@ react-draggable@^4.4.3:
     classnames "^2.2.5"
     prop-types "^15.6.0"
 
+react-easy-crop@^3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/react-easy-crop/-/react-easy-crop-3.5.2.tgz#1fc65249e82db407c8c875159589a8029a9b7a06"
+  integrity sha512-cwSGO/wk42XDpEyrdAcnQ6OJetVDZZO2ry1i19+kSGZQ750aN06RU9y9z95B5QI6sW3SnaWQRKv5r5GSqVV//g==
+  dependencies:
+    normalize-wheel "^1.0.1"
+    tslib "2.0.1"
+
 react-element-to-jsx-string@^14.3.2:
   version "14.3.2"
   resolved "https://registry.yarnpkg.com/react-element-to-jsx-string/-/react-element-to-jsx-string-14.3.2.tgz#c0000ed54d1f8b4371731b669613f2d4e0f63d5c"
@@ -10257,7 +10432,7 @@ react-inspector@^5.1.0:
     is-dom "^1.0.0"
     prop-types "^15.0.0"
 
-react-is@17.0.2, react-is@^17.0.1, react-is@^17.0.2:
+react-is@17.0.2, "react-is@^16.8.0 || ^17.0.0", react-is@^17.0.1, react-is@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
@@ -10357,7 +10532,7 @@ react-textarea-autosize@^8.3.0:
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
 
-react-transition-group@^4.3.0:
+react-transition-group@^4.3.0, react-transition-group@^4.4.0:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.2.tgz#8b59a56f09ced7b55cbd53c36768b922890d5470"
   integrity sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==
@@ -11812,6 +11987,11 @@ timers-browserify@2.0.12, timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
+tiny-warning@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
+  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
+
 tlds@^1.199.0:
   version "1.221.1"
   resolved "https://registry.yarnpkg.com/tlds/-/tlds-1.221.1.tgz#6cf6bff5eaf30c5618c5801c3f425a6dc61ca0ad"
@@ -11936,6 +12116,11 @@ tsconfig-paths@^3.9.0:
     json5 "^1.0.1"
     minimist "^1.2.0"
     strip-bom "^3.0.0"
+
+tslib@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
+  integrity sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==
 
 tslib@^1.8.1:
   version "1.14.1"


### PR DESCRIPTION
> Resolve [#S05P13A202-292](https://jira.ssafy.com/browse/S05P13A202-292)

이미지를 업로드 하는 일과 프리뷰하게 보여주는 일이 별개라는 사실을 알게 되었습니다. 때문에 프리뷰가 가능하게 만들었습니다. 이 과정에서 저희 사이트의 경우 원형의 프로필 이미지가 필요하다보니 사용자가 이미지를 동그랗게 잘라서 사용할 수 있는 기능을 추가 하였습니다. 현재 이미지를 자르는 모양은 원형이지만 실제 잘리는 모양은 정사각형이기 때문에 추후에 이미지를 사용할 때 border-radius 값을 50% 주어서 사용해야 합니다.