### PR TITLE
feat: 사용자가 채팅방의 메세지를 어디까지 읽었는지 알 수 있다

### DIFF
--- a/BE/teamgu/src/main/java/com/teamgu/api/controller/ChatController.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/controller/ChatController.java
@@ -21,6 +21,7 @@ import com.teamgu.api.dto.req.ChatReqDto;
 import com.teamgu.api.dto.req.UserInviteTeamReqDto;
 import com.teamgu.api.dto.req.UserRoomCheckDto;
 import com.teamgu.api.dto.req.UserRoomInviteReqDto;
+import com.teamgu.api.dto.req.UserRoomOutCheckReqDto;
 import com.teamgu.api.dto.res.BaseResDto;
 import com.teamgu.api.dto.res.BasicResponse;
 import com.teamgu.api.dto.res.ChatMessageResDto;
@@ -33,6 +34,7 @@ import com.teamgu.api.service.ChatServiceImpl;
 import com.teamgu.api.service.UserServiceImpl;
 import com.teamgu.api.vo.MessageTemplate;
 import com.teamgu.database.entity.Chat;
+import com.teamgu.database.repository.TeamRepositorySupport;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -53,6 +55,9 @@ public class ChatController {
 	
 	@Autowired
 	UserServiceImpl userService;
+	
+	@Autowired 
+	TeamRepositorySupport teamRepositorySupport;
 	
 	@Autowired
 	MessageTemplate simpMessagingTemplate;
@@ -160,6 +165,17 @@ public class ChatController {
 		}
 		return ResponseEntity.noContent().build();
 	}
+	
+	@PostMapping("/room/out")
+	@ApiOperation(value="특정 유저가 채팅방을 닫았을 때, 마지막 채팅 내역이 무엇인지 기록한다")
+	public ResponseEntity<? extends BasicResponse> roomOutCheck(@RequestBody UserRoomOutCheckReqDto userRoomOutCheckReqDto){
+		long room_id = userRoomOutCheckReqDto.getRoom_id();
+		long user_id = userRoomOutCheckReqDto.getUser_id();
+		long last_chat_id = chatService.findLastChatId(room_id);
+		chatService.writeLastChatId(room_id, user_id, last_chat_id);		
+		return ResponseEntity.noContent().build();
+	}
+	
 	
 //	@PostMapping("/rtc/user-invite")
 //	@ApiOperation(value="채팅을 통해 1:1 RTC 세션으로 초대합니다")

--- a/BE/teamgu/src/main/java/com/teamgu/api/controller/ChatController.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/controller/ChatController.java
@@ -26,6 +26,7 @@ import com.teamgu.api.dto.res.BaseResDto;
 import com.teamgu.api.dto.res.BasicResponse;
 import com.teamgu.api.dto.res.ChatMessageResDto;
 import com.teamgu.api.dto.res.ChatRoomResDto;
+import com.teamgu.api.dto.res.ChatTotalUnreadResDto;
 import com.teamgu.api.dto.res.CommonResponse;
 import com.teamgu.api.dto.res.ErrorResponse;
 import com.teamgu.api.dto.res.LoginResDto;
@@ -176,7 +177,12 @@ public class ChatController {
 		return ResponseEntity.noContent().build();
 	}
 	
-	
+	@GetMapping("/unread/{userid}")
+	@ApiOperation(value="특정 유저의 읽지 않은 메세지 총 갯수를 반환한다")
+	public ResponseEntity<? extends BasicResponse> getUnreadMessageByUserId(@PathVariable("userid") @ApiParam(value ="조회하고자 하는 유저의 id 값",required=true) long user_id){
+		long unreadCount = chatService.countTotalUnreadMessage(user_id);
+		return ResponseEntity.ok(new CommonResponse<ChatTotalUnreadResDto>(ChatTotalUnreadResDto.builder().unreadcount(unreadCount).build()));		
+	}
 //	@PostMapping("/rtc/user-invite")
 //	@ApiOperation(value="채팅을 통해 1:1 RTC 세션으로 초대합니다")
 //	@ApiResponses({

--- a/BE/teamgu/src/main/java/com/teamgu/api/controller/StompChatController.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/controller/StompChatController.java
@@ -75,6 +75,10 @@ public class StompChatController {
 		}
 		else
 			log.error("message db save failed");
+		
+		// 종료 시점 기록 엔드포인트를 거치지 않고 나갈 수 있기 때문에 마지막 채팅 id를 갱신해준다
+		long last_chat_id = chatService.findLastChatId(message.getRoom_id());
+		chatService.writeLastChatId(message.getRoom_id(), message.getSender_id(), last_chat_id);		
 	}
 	
 	/**

--- a/BE/teamgu/src/main/java/com/teamgu/api/controller/StompChatController.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/controller/StompChatController.java
@@ -62,14 +62,15 @@ public class StompChatController {
 		log.info(chatres.getMessage());
 		log.info(chatres.getSendDateTime());
 		if (chatres!=null) {
-			ChatMessageResDto chatMessageResDto = new ChatMessageResDto(message.getSender_id(), 
-					sender.getName(),
-					chatres.getType(),
-					chatres.getMessage(), 
-					chatres.getSendDateTime(),
-					0
-					);
-			simpMessagingTemplate.getTemplate().convertAndSend("/receive/chat/room/"+message.getRoom_id(),chatMessageResDto);			
+			ChatMessageResDto chatMessageResDto = ChatMessageResDto.builder()
+																	.chat_id(chatres.getId())
+																	.sender_id(message.getSender_id())
+																	.sender_name(sender.getName())
+																	.type(chatres.getType())
+																	.message(chatres.getMessage())
+																	.create_date_time(chatres.getSendDateTime())
+																	.unread_user_count(0)
+																	.build();simpMessagingTemplate.getTemplate().convertAndSend("/receive/chat/room/"+message.getRoom_id(),chatMessageResDto);			
 			log.info("message db saved done");
 		}
 		else

--- a/BE/teamgu/src/main/java/com/teamgu/api/dto/req/UserRoomOutCheckReqDto.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/dto/req/UserRoomOutCheckReqDto.java
@@ -1,0 +1,17 @@
+package com.teamgu.api.dto.req;
+
+import io.swagger.annotations.ApiModel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ApiModel(description = "유저의 채팅 체크아웃 모델")
+public class UserRoomOutCheckReqDto {
+	long user_id;
+	long room_id;
+}

--- a/BE/teamgu/src/main/java/com/teamgu/api/dto/res/ChatMessageResDto.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/dto/res/ChatMessageResDto.java
@@ -21,6 +21,9 @@ import lombok.NoArgsConstructor;
 @Builder
 @ApiModel("ChatMessageResponse")
 public class ChatMessageResDto {
+	@ApiModelProperty(name="채팅의 고유 id")
+	long chat_id;
+	
 	@ApiModelProperty(name="보내는 사람의 아이디")
 	long sender_id;
 	

--- a/BE/teamgu/src/main/java/com/teamgu/api/dto/res/ChatRoomResDto.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/dto/res/ChatRoomResDto.java
@@ -4,8 +4,10 @@ import java.time.LocalDateTime;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 /**
@@ -17,13 +19,11 @@ import lombok.Setter;
 
 @Getter
 @Setter
-//@Builder
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @ApiModel("ChatResponse")
-public class ChatRoomResDto extends BaseResDto{
-	public ChatRoomResDto() {
-		// TODO Auto-generated constructor stub
-	}
-
+public class ChatRoomResDto{
 	@ApiModelProperty(name="채팅방 고유 ID")
 	long chat_room_id;
 //	String chat_room_id; //id로 테스트후 랜덤uuid로 변경 예정
@@ -33,6 +33,9 @@ public class ChatRoomResDto extends BaseResDto{
 	
 	@ApiModelProperty(name="마지막 채팅 메세지") 
 	String last_chat_message;
+	
+	@ApiModelProperty(name="사용자가 마지막으로 읽은 메세지 id")
+	long out_check_chat_id;
 	
 //	@ApiModelProperty(name="안읽은 메세지 갯수")
 //	int unread_message_count;

--- a/BE/teamgu/src/main/java/com/teamgu/api/dto/res/ChatRoomResDto.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/dto/res/ChatRoomResDto.java
@@ -37,8 +37,8 @@ public class ChatRoomResDto{
 	@ApiModelProperty(name="사용자가 마지막으로 읽은 메세지 id")
 	long out_check_chat_id;
 	
-//	@ApiModelProperty(name="안읽은 메세지 갯수")
-//	int unread_message_count;
+	@ApiModelProperty(name="안읽은 메세지 갯수")
+	long unread_message_count;
 	
 	@ApiModelProperty(name="마지막 채팅 메세지 보낸 시간")
 	LocalDateTime send_date_time;

--- a/BE/teamgu/src/main/java/com/teamgu/api/dto/res/ChatTotalUnreadResDto.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/dto/res/ChatTotalUnreadResDto.java
@@ -1,0 +1,18 @@
+package com.teamgu.api.dto.res;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ApiModel("ChatUnreadTotal")
+public class ChatTotalUnreadResDto {
+	@ApiModelProperty(name="읽지 않은 메세지 갯수")
+	long unreadcount;
+}

--- a/BE/teamgu/src/main/java/com/teamgu/api/service/ChatService.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/service/ChatService.java
@@ -79,4 +79,11 @@ public interface ChatService {
 	 * @param chat_id
 	 */
 	void writeLastChatId(long room_id, long user_id, long chat_id);
+	
+	/**
+	 * 특정 유저의 읽지 않은 메세지 갯수를 가져온다
+	 * @param user_id
+	 * @return
+	 */
+	long countTotalUnreadMessage(long user_id);
 }

--- a/BE/teamgu/src/main/java/com/teamgu/api/service/ChatService.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/service/ChatService.java
@@ -64,4 +64,19 @@ public interface ChatService {
 	 * @return
 	 */
 	ChatRoomResDto getChatRoomInfo(long room_id);
+	
+	/**
+	 * 특정 채팅방의 마지막 채팅 id를 기록한다
+	 * @param room_id
+	 * @return
+	 */
+	long findLastChatId(long room_id);
+	
+	/**
+	 * 특정 채팅방에서 나갔을 때, 나간 유저의 마지막 채팅id가 무엇이었는지 기록한다
+	 * @param room_id
+	 * @param user_id
+	 * @param chat_id
+	 */
+	void writeLastChatId(long room_id, long user_id, long chat_id);
 }

--- a/BE/teamgu/src/main/java/com/teamgu/api/service/ChatServiceImpl.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/service/ChatServiceImpl.java
@@ -62,16 +62,25 @@ public class ChatServiceImpl implements ChatService{
 		List<UserChatRoom> userChatRoomList = userChatRoomRepository.findByUserId(userid); //JPAQueryFactory 이용
 		log.debug("userChatRoomList 갯수 : "+userChatRoomList.size());
 		List<ChatRoomResDto> chatRoomResDtoList = new ArrayList<ChatRoomResDto>();
-		for(UserChatRoom userChatRoom:userChatRoomList) {
+		for(UserChatRoom userChatRoom:userChatRoomList) {			
 			long chatroomid = userChatRoom.getChatRoom().getId();
 			
-			//해당 목록에서 필요한 정보를 DtoList에 저장한다.
-			ChatRoomResDto crrd = new ChatRoomResDto();
-			crrd.setChat_room_id(chatroomid);
-			crrd.setRoom_name(chatRoomRepository.findById(chatroomid).get().getTitle());//채팅방 이름을 가져온다
 			Chat lastchat = chatRoomRepositorySupport.getLastMessage(chatroomid);
-			crrd.setLast_chat_message(lastchat.getMessage());//해당 채팅방의 마지막 메세지를 가져온다.
-			crrd.setSend_date_time(lastchat.getSendDateTime());//해당 채팅방의 마지막 전송 시간을 가져온다.			
+			long last_chat_id = 0;
+			try {
+				last_chat_id = userChatRoom.getChat().getId();
+			}
+			catch(Exception e) {
+				log.error("userChatRoom.getChat().getId()가 null입니다");
+			}
+			//해당 목록에서 필요한 정보를 DtoList에 저장한다.
+			ChatRoomResDto crrd = ChatRoomResDto.builder()
+												.chat_room_id(chatroomid)
+												.room_name(chatRoomRepository.findById(chatroomid).get().getTitle())
+												.last_chat_message(lastchat.getMessage())//해당 채팅방의 마지막 메세지를 가져온다.
+												.send_date_time(lastchat.getSendDateTime())//해당 채팅방의 마지막 전송 시간을 가져온다.
+												.out_check_chat_id(last_chat_id)//마지막 채팅 id
+												.build();
 			chatRoomResDtoList.add(crrd);
 		}
 		log.debug("반환하는 chatRoomResDtoList 갯수 : "+chatRoomResDtoList.size());
@@ -86,6 +95,7 @@ public class ChatServiceImpl implements ChatService{
 		List<ChatMessageResDto> chatMessageResDtoList = new ArrayList<ChatMessageResDto>();
 		for(Chat chat:chatRepositorySupport.findByReceiveRoomId(chatRoomId)) {			
 			ChatMessageResDto chatMessageResDto = ChatMessageResDto.builder()
+													.chat_id(chat.getId())
 													.message(chat.getMessage())
 													.sender_id(chat.getUser().getId())
 													.sender_name(chat.getUser().getName())
@@ -153,5 +163,15 @@ public class ChatServiceImpl implements ChatService{
 	@Override
 	public ChatRoomResDto getChatRoomInfo(long room_id) {		
 		return chatRoomRepositorySupport.getRoomInfo(room_id);
+	}
+	
+	@Override
+	public long findLastChatId(long room_id) {
+		return chatRepositorySupport.findLastChatId(room_id);
+	}
+	
+	@Override
+	public void writeLastChatId(long room_id, long user_id, long chat_id) {
+		chatRepositorySupport.writeLastChatId(room_id, user_id, chat_id);
 	}
 }

--- a/BE/teamgu/src/main/java/com/teamgu/api/service/ChatServiceImpl.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/service/ChatServiceImpl.java
@@ -73,6 +73,9 @@ public class ChatServiceImpl implements ChatService{
 			catch(Exception e) {
 				log.error("userChatRoom.getChat().getId()가 null입니다");
 			}
+			
+			long unreadCount = userChatRoomRepositorySupport.countUnreadMessageByUserIdAndRoomId(userid, chatroomid);
+			
 			//해당 목록에서 필요한 정보를 DtoList에 저장한다.
 			ChatRoomResDto crrd = ChatRoomResDto.builder()
 												.chat_room_id(chatroomid)
@@ -80,6 +83,7 @@ public class ChatServiceImpl implements ChatService{
 												.last_chat_message(lastchat.getMessage())//해당 채팅방의 마지막 메세지를 가져온다.
 												.send_date_time(lastchat.getSendDateTime())//해당 채팅방의 마지막 전송 시간을 가져온다.
 												.out_check_chat_id(last_chat_id)//마지막 채팅 id
+												.unread_message_count(unreadCount)//아직 읽지 않은 메세지도 기록
 												.build();
 			chatRoomResDtoList.add(crrd);
 		}
@@ -173,5 +177,10 @@ public class ChatServiceImpl implements ChatService{
 	@Override
 	public void writeLastChatId(long room_id, long user_id, long chat_id) {
 		chatRepositorySupport.writeLastChatId(room_id, user_id, chat_id);
+	}
+	
+	@Override
+	public long countTotalUnreadMessage(long user_id) {
+		return userChatRoomRepositorySupport.countUnreadMessageByUserId(user_id);
 	}
 }

--- a/BE/teamgu/src/main/java/com/teamgu/database/repository/ChatRepositorySupport.java
+++ b/BE/teamgu/src/main/java/com/teamgu/database/repository/ChatRepositorySupport.java
@@ -2,6 +2,11 @@ package com.teamgu.database.repository;
 
 import java.util.List;
 
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.EntityTransaction;
+import javax.persistence.PersistenceUnit;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
@@ -18,6 +23,9 @@ public class ChatRepositorySupport {
 	@Autowired
 	private JPAQueryFactory jpaQueryFactory;
 	QChat qChat = QChat.chat;
+
+	@PersistenceUnit
+	EntityManagerFactory emf;
 	
 	public List<Chat> findByReceiveRoomId(long id){
 		log.info("Support의 findByReceiveRoomID 진입");
@@ -27,5 +35,42 @@ public class ChatRepositorySupport {
 											.fetch();
 		log.info(id+"룸의 메세지 갯수 : "+chatList.size());
 		return chatList;
+	}
+	
+	/**
+	 * 특정 채팅방의 마지막 메세지 id를 반환한다
+	 * @param room_id
+	 * @return
+	 */
+	public long findLastChatId(long room_id) {
+		Chat lastChat = jpaQueryFactory.select(qChat)
+				.from(qChat)
+				.where(qChat.chatRoom.id.eq(room_id))
+				.orderBy(qChat.id.desc())
+				.fetchFirst();		
+		return lastChat.getId();		
+	}
+	
+	/**
+	 * 특정 채팅방에 특정 유저의 마지막 챗id를 기록한다
+	 * @param room_id
+	 * @param user_id
+	 * @param chat_id
+	 */
+	public void writeLastChatId(long room_id, long user_id,long chat_id) {
+		EntityManager em = emf.createEntityManager();
+		EntityTransaction et = em.getTransaction();
+		et.begin();
+		String jpql = "UPDATE user_chat_room\r\n"
+					+ "SET last_chat_id = :chat_id\r\n"
+					+ "WHERE chat_room_id = :room_id\r\n"
+					+ "AND user_id = :user_id";
+		em.createNativeQuery(jpql)
+							.setParameter("chat_id", chat_id)
+							.setParameter("room_id", room_id)
+							.setParameter("user_id", user_id)
+							.executeUpdate();
+		et.commit();
+		em.close();
 	}
 }

--- a/BE/teamgu/src/main/java/com/teamgu/database/repository/UserChatRoomRepositorySupport.java
+++ b/BE/teamgu/src/main/java/com/teamgu/database/repository/UserChatRoomRepositorySupport.java
@@ -1,5 +1,6 @@
 package com.teamgu.database.repository;
 
+import java.math.BigInteger;
 import java.util.List;
 
 import javax.persistence.EntityManager;
@@ -72,5 +73,54 @@ public class UserChatRoomRepositorySupport {
 			.executeUpdate();
 		et.commit();
 		em.close();
+	}
+	
+	/**
+	 * 특정 채팅 방의 unread 메세지를 반환한다
+	 * @param user_id
+	 * @param room_id
+	 * @return
+	 */
+	public long countUnreadMessageByUserIdAndRoomId(long user_id,long room_id) {
+		EntityManager em = emf.createEntityManager();
+		String jpql = 	"select ifnull(count(*),0) unread_message\r\n" + 
+						"from chat c \r\n" + 
+						"where c.receive_room_id= :room_id and c.id > (select ifnull(ucr.last_chat_id,0) \r\n" + 
+																"from user_chat_room ucr \r\n" + 
+																"where ucr.user_id=:user_id and ucr.chat_room_id=:room_id)\r\n" + 
+						"group by c.receive_room_id\r\n" + 
+						"union all\r\n" + 
+						"select 0 as unread_message\r\n" + 
+						"from dual\r\n" + 
+						"limit 1";
+		List<Long> res = em.createNativeQuery(jpql)
+							.setParameter("user_id", user_id)
+							.setParameter("room_id", room_id)
+							.getResultList();
+		em.close();
+		return res.get(0).longValue();
+	}
+	
+	/**
+	 * 특정 유저의 전체 메세지 목록 중 unread 메세지를 반환한다
+	 * @param user_id
+	 * @return
+	 */
+	public long countUnreadMessageByUserId(long user_id) {
+		EntityManager em = emf.createEntityManager();
+		String jpql = 	"SELECT count(*) res\r\n" + 
+				"FROM chat c\r\n" + 
+				"LEFT JOIN (SELECT chat_room_id , IFNULL(last_chat_id,0) last_chat_id\r\n" + 
+							"FROM user_chat_room\r\n" + 
+							"WHERE user_id=:user_id) ucr\r\n" + 
+				"ON ucr.chat_room_id=c.receive_room_id\r\n" + 
+				"WHERE c.id > ucr.last_chat_id";
+		List<BigInteger> res = em.createNativeQuery(jpql)
+				.setParameter("user_id", user_id)
+				.getResultList();
+		log.info(user_id+" 조회된 unread total : "+res.get(0).longValue());
+		em.close();
+		return res.get(0).longValue();
+		
 	}
 }


### PR DESCRIPTION
- 채팅방을 나갈 때 마지막 메세지 id를 기록하는 앤드포인트 추가
- 채팅방 목록을 조회할 때 마지막 메세지 id를 반환하도록 메서드 ResDto 수정
- 특정 사용자의 모든 미열람 채팅 갯수 반환 엔드포인트 추가 (실시간 조회에 쓰일 예정)
- 특정 사용자 기준 한 채팅방의 미열람 채팅 갯수 반환 엔드포인트 추가

#S05P13A202-295, #S05P13A202-104