### PR TITLE
채팅 기능의 팀 초대, 수락, 거절, 만료를 추가한다

### DIFF
--- a/BE/teamgu/src/main/java/com/teamgu/api/controller/ChatController.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/controller/ChatController.java
@@ -306,9 +306,10 @@ public class ChatController {
 			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponse("팀 초대 상태가 만료되었습니다"));
 		}
 		//3. 문제 없다면 팀 초대
-		TeamMemberReqDto teamMemberReqDto = new TeamMemberReqDto();
-		teamMemberReqDto.setTeamId(team_id);
-		teamMemberReqDto.setUserId(invitee_id);
+		TeamMemberReqDto teamMemberReqDto = TeamMemberReqDto.builder()
+												.teamId(team_id)
+												.userId(invitee_id)
+												.build();
 		teamService.addMember(teamMemberReqDto);
 		TeamListResDto team = teamService.getTeamInfobyTeamId(team_id);
 		chatService.changeType(message_id, messageTypeVo.getInviteAccepted());

--- a/BE/teamgu/src/main/java/com/teamgu/api/controller/ChatController.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/controller/ChatController.java
@@ -329,14 +329,11 @@ public class ChatController {
 		long team_id = teamInviteResponseReqDto.getTeam_id();
 		long message_id = teamInviteResponseReqDto.getMessage_id();
 		
-		TeamMemberReqDto teamMemberReqDto = new TeamMemberReqDto();
-		teamMemberReqDto.setTeamId(team_id);
-		teamMemberReqDto.setUserId(invitee_id);
-		TeamListResDto team = teamService.getTeamInfobyTeamId(team_id);
-		
-		chatService.changeType(message_id, messageTypeVo.getInviteRejected());
+		boolean res = chatService.changeType(message_id, messageTypeVo.getInviteRejected());
+		if(!res)
+			return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(new ErrorResponse("유효한 메세지를 찾을 수 없습니다"));
 		log.info(invitee_id+"유저는 "+team_id+"의 초대를 거절했습니다");
 
-		return ResponseEntity.ok(new CommonResponse<TeamListResDto>(team));	
+		return ResponseEntity.ok(new CommonResponse<String>("정상적으로 거절 되었습니다"));
 	}
 }

--- a/BE/teamgu/src/main/java/com/teamgu/api/controller/ChatController.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/controller/ChatController.java
@@ -281,6 +281,10 @@ public class ChatController {
 	 */
 	@PostMapping("/message/team/invite/accept")
 	@ApiOperation(value="팀 초대 메세지를 수락한다")
+	@ApiResponses({
+		@ApiResponse(code = 200, message = "팀 가입 성공"),
+		@ApiResponse(code = 400, message = "팀 가입 실패",response = BaseResDto.class)
+	})
 	public ResponseEntity<? extends BasicResponse> teamInviteAccept(@RequestBody TeamInviteResponseReqDto teamInviteResponseReqDto){
 		long leader_id = teamInviteResponseReqDto.getLeader_id();
 		long invitee_id = teamInviteResponseReqDto.getInvitee_id();

--- a/BE/teamgu/src/main/java/com/teamgu/api/controller/ChatController.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/controller/ChatController.java
@@ -24,6 +24,8 @@ import com.teamgu.api.dto.req.ChatReqDto;
 import com.teamgu.api.dto.req.ChatRoomLeaveReqDto;
 import com.teamgu.api.dto.req.ChatRoomModifyReqDto;
 import com.teamgu.api.dto.req.ChatRoomRegistReqDto;
+import com.teamgu.api.dto.req.TeamInviteResponseReqDto;
+import com.teamgu.api.dto.req.TeamMemberReqDto;
 import com.teamgu.api.dto.req.UserInviteTeamReqDto;
 import com.teamgu.api.dto.req.UserRoomCheckDto;
 import com.teamgu.api.dto.req.UserRoomInviteReqDto;
@@ -36,11 +38,14 @@ import com.teamgu.api.dto.res.ChatTotalUnreadResDto;
 import com.teamgu.api.dto.res.CommonResponse;
 import com.teamgu.api.dto.res.ErrorResponse;
 import com.teamgu.api.dto.res.LoginResDto;
+import com.teamgu.api.dto.res.TeamListResDto;
 import com.teamgu.api.dto.res.UserChatSearchResDto;
 import com.teamgu.api.service.ChatService;
 import com.teamgu.api.service.ChatServiceImpl;
+import com.teamgu.api.service.TeamServiceImpl;
 import com.teamgu.api.service.UserServiceImpl;
 import com.teamgu.api.vo.MessageTemplate;
+import com.teamgu.api.vo.MessageTypeVo;
 import com.teamgu.database.entity.Chat;
 import com.teamgu.database.entity.User;
 import com.teamgu.database.repository.TeamRepositorySupport;
@@ -70,6 +75,12 @@ public class ChatController {
 	
 	@Autowired
 	MessageTemplate simpMessagingTemplate;
+	
+	@Autowired
+	TeamServiceImpl teamService;
+	
+	@Autowired
+	MessageTypeVo messageTypeVo;
 	/**
 	 * 특정 유저의 채팅방 목록을 가져온다
 	 */
@@ -115,37 +126,6 @@ public class ChatController {
 					.body(new ErrorResponse("채팅 메세지 저장에 실패했습니다."));
 		}
 		return ResponseEntity.noContent().build();
-	}
-	
-	/**
-	 * 
-	 * @param users
-	 * @return
-	 */
-	@PostMapping("/message/team/invite")
-	@ApiOperation(value="특정 유저에게 팀원 초대 요청을 보낸다")
-	public ResponseEntity<? extends BasicResponse> sendTeamInviteMessage(@RequestBody UserInviteTeamReqDto userInviteTeamReqDto){
-		long result = chatService.roomCheck(userInviteTeamReqDto.getLeader_id(), userInviteTeamReqDto.getInvitee_id());
-		if(result==0) {//존재하지 않는 경우 방을 생성하고 방 번호를 반환한다.
-			long user_id1 = userInviteTeamReqDto.getLeader_id();
-			long user_id2 = userInviteTeamReqDto.getInvitee_id();
-			String name1 = userService.getUserById(user_id1).get().getName();
-			String name2 = userService.getUserById(user_id2).get().getName();
-			//미구현
-//			result = chatService.createRoom(name1+", "+name2+"의 방");
-//			log.info(result+"방이 생성되었습니다");
-//			
-//			chatService.inviteUser(userInviteTeamReqDto.getLeader_id(), result);
-//			chatService.inviteUser(userInviteTeamReqDto.getInvitee_id(), result);
-			//여기서 해당 채팅방에 leader to invitee로 팀원 초대 메세지를 보낸다.
-			
-			//1. DB에 먼저 저장
-			
-			//2. Receive로 메세지 보내기
-			
-			//3. 팀으로 초대하기 위해선 팀 코드가 필요
-		}
-		return ResponseEntity.ok(new CommonResponse<Long>(result));	
 	}
 	
 	@PostMapping("/room/check")
@@ -292,5 +272,66 @@ public class ChatController {
 		log.info("invite 테스팅");
 		simpMessagingTemplate.getTemplate().convertAndSend("/receive/chat/room/"+125,ChatMessageResDto.builder().message("test"));
 		return ResponseEntity.ok(new CommonResponse<Boolean>(true));
+	}
+
+	/**
+	 * 팀초대 메세지에 대한 수락 응답을 처리한다
+	 * @param teamInviteResponseReqDto
+	 * @return
+	 */
+	@PostMapping("/message/team/invite/accept")
+	@ApiOperation(value="팀 초대 메세지를 수락한다")
+	public ResponseEntity<? extends BasicResponse> teamInviteAccept(@RequestBody TeamInviteResponseReqDto teamInviteResponseReqDto){
+		long leader_id = teamInviteResponseReqDto.getLeader_id();
+		long invitee_id = teamInviteResponseReqDto.getInvitee_id();
+		long team_id = teamInviteResponseReqDto.getTeam_id();
+		long message_id = teamInviteResponseReqDto.getMessage_id();
+		TeamListResDto teamListResDto = teamService.getTeamInfobyTeamId(team_id);
+		String trackName = teamListResDto.getTrack().getCodeName();
+		
+		//오류 대상
+		//1. 팀에 들어갈 수 있는 상태인가? = 이미 존재하는 멤버를 검증할 필요가 없음 (이미존재하는 멤버 = 팀이 있음)
+		boolean visibleTeam = teamService.checkTeamBuilding(invitee_id, trackName);
+		if(!visibleTeam)
+			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponse("팀에 들어갈 수 없는 상태입니다"));
+		//2. 팀의 리더가 바뀐 후의 수락상태
+		boolean visibleInvite = teamService.checkTeamBetweenLeader(leader_id, team_id);
+		if(!visibleInvite) {//만료된 초대, 팀의 정보가 온전하지 않을 때
+			//update expired로 변경
+			chatService.changeType(message_id, messageTypeVo.getInviteExpired());
+			return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ErrorResponse("팀 초대 상태가 만료되었습니다"));
+		}
+		//3. 문제 없다면 팀 초대
+		TeamMemberReqDto teamMemberReqDto = new TeamMemberReqDto();
+		teamMemberReqDto.setTeamId(team_id);
+		teamMemberReqDto.setUserId(invitee_id);
+		teamService.addMember(teamMemberReqDto);
+		TeamListResDto team = teamService.getTeamInfobyTeamId(team_id);
+		chatService.changeType(message_id, messageTypeVo.getInviteAccepted());
+		log.info(invitee_id+"유저는 "+team_id+"로 팀 초대가 이루어졌습니다.");
+		return ResponseEntity.ok(new CommonResponse<TeamListResDto>(team));	
+	}
+	
+	/**
+	 * 팀초대 메세지에 대한 거절 응답을 처리한다
+	 * @param teamInviteResponseReqDto
+	 * @return
+	 */
+	@PostMapping("/message/team/invite/reject")
+	@ApiOperation(value="팀 초대 메세지를 거절한다")
+	public ResponseEntity<? extends BasicResponse> teamInviteReject(@RequestBody TeamInviteResponseReqDto teamInviteResponseReqDto){
+		long invitee_id = teamInviteResponseReqDto.getInvitee_id();
+		long team_id = teamInviteResponseReqDto.getTeam_id();
+		long message_id = teamInviteResponseReqDto.getMessage_id();
+		
+		TeamMemberReqDto teamMemberReqDto = new TeamMemberReqDto();
+		teamMemberReqDto.setTeamId(team_id);
+		teamMemberReqDto.setUserId(invitee_id);
+		TeamListResDto team = teamService.getTeamInfobyTeamId(team_id);
+		
+		chatService.changeType(message_id, messageTypeVo.getInviteRejected());
+		log.info(invitee_id+"유저는 "+team_id+"의 초대를 거절했습니다");
+
+		return ResponseEntity.ok(new CommonResponse<TeamListResDto>(team));	
 	}
 }

--- a/BE/teamgu/src/main/java/com/teamgu/api/dto/req/TeamInviteResponseReqDto.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/dto/req/TeamInviteResponseReqDto.java
@@ -1,0 +1,24 @@
+package com.teamgu.api.dto.req;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ApiModel(description = "팀 초대 요청에 응답을 했을 때 사용되는 모델")
+public class TeamInviteResponseReqDto {
+	@ApiModelProperty(name="초대 될 팀의 id")
+	long team_id;
+	@ApiModelProperty(name="초대를 하는 팀장의 id")
+	long leader_id;
+	@ApiModelProperty(name="초대를 받는 유저의 id")
+	long invitee_id;
+	@ApiModelProperty(name="해당 요청의 메세지 id")
+	long message_id;
+}

--- a/BE/teamgu/src/main/java/com/teamgu/api/dto/req/TeamMemberReqDto.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/dto/req/TeamMemberReqDto.java
@@ -2,11 +2,17 @@ package com.teamgu.api.dto.req;
 
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@Getter
-@Setter
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @ApiModel(description = "팀 구성시 멤버 정보 요청 모델")
 public class TeamMemberReqDto {
 

--- a/BE/teamgu/src/main/java/com/teamgu/api/service/ChatService.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/service/ChatService.java
@@ -131,4 +131,9 @@ public interface ChatService {
 	 * @return
 	 */
 	List<Long> getRoomUserList(long room_id);
+	
+	/**
+	 * 특정 채팅의 type을 변경한다
+	 */
+	boolean changeType(long chat_id,String type);	
 }

--- a/BE/teamgu/src/main/java/com/teamgu/api/service/ChatServiceImpl.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/service/ChatServiceImpl.java
@@ -234,4 +234,9 @@ public class ChatServiceImpl implements ChatService{
 	public boolean modifyRoomName(String title, long room_id) {		
 		return chatRoomRepositorySupport.modifyRoomName(title, room_id);
 	}	
+	
+	@Override
+	public boolean changeType(long chat_id, String type) {
+		return chatRepositorySupport.changeType(chat_id, type);
+	}
 }

--- a/BE/teamgu/src/main/java/com/teamgu/api/service/TeamService.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/service/TeamService.java
@@ -55,4 +55,12 @@ public interface TeamService {
 	// Auto complete
 	List<TeamAutoCorrectResDto> getUserAutoCorrect(TeamAutoCorrectReqDto teamSearchReqDto);
 	
+	/**
+	 * 리더id와 팀id를 대조하여 유효한 팀 초대인지 확인한다
+	 * @param leader_id
+	 * @param team_id
+	 * @return
+	 */
+	boolean checkTeamBetweenLeader(long leader_id, long team_id);
+	
 }

--- a/BE/teamgu/src/main/java/com/teamgu/api/service/TeamServiceImpl.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/service/TeamServiceImpl.java
@@ -389,4 +389,8 @@ public class TeamServiceImpl implements TeamService {
 		return teamRepositorySupport.checkTeamLeader(userId, projectCode);
 	}
 	
+	@Override
+	public boolean checkTeamBetweenLeader(long leader_id, long team_id) {	
+		return teamRepositorySupport.checkTeamBetweenLeader(leader_id, team_id);
+	}
 }

--- a/BE/teamgu/src/main/java/com/teamgu/api/vo/MessageTypeVo.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/vo/MessageTypeVo.java
@@ -1,0 +1,15 @@
+package com.teamgu.api.vo;
+
+import org.springframework.stereotype.Component;
+
+import lombok.Getter;
+
+@Component
+@Getter
+public class MessageTypeVo {
+	String inviteWaiting = "TEAM_INVITE_WAITING";
+	String inviteAccepted = "TEAM_INVITE_ACCEPTED";
+	String inviteRejected = "TEAM_INVITE_REJECTED";
+	String inviteExpired = "TEAM_INVITE_EXPIRED";
+	String recInvite = "RTC_INVITE";
+}

--- a/BE/teamgu/src/main/java/com/teamgu/database/entity/Chat.java
+++ b/BE/teamgu/src/main/java/com/teamgu/database/entity/Chat.java
@@ -30,11 +30,11 @@ public class Chat extends BaseEntity{
 	
 	/**
 	 * type에 대한 정의
-	 * NORMAL		그냥 일반 메세지다
-     * TEAM_INVITE_12_WAITING       요청을 보냈으나 아직 응답을 안 한 상태, _ 뒤엔 반드시 팀 코드가 포함되어야한다.
-     * TEAM_INVITE_12_ACCEPTED        요청을 보냈고 수락한 상태
-     * TEAM_INVITE_12_REJECTED        요청을 보냈고 거절한 상태
-     * TEAM_INVITE_12_EXPIRED	요청을 보냈으나 만료된 상태
+	 * NORMAL		그냥 일반 메세지
+     * TEAM_INVITE_WAITING       요청을 보냈으나 아직 응답을 안 한 상태, _ 뒤엔 반드시 팀 코드가 포함되어야한다.
+     * TEAM_INVITE_ACCEPTED        요청을 보냈고 수락한 상태
+     * TEAM_INVITE_REJECTED        요청을 보냈고 거절한 상태
+     * TEAM_INVITE_EXPIRED	요청을 보냈으나 만료된 상태
      * RTC_INVITE	방 번호를 같이 보낸다
 	 */
 	String type;

--- a/BE/teamgu/src/main/java/com/teamgu/database/repository/ChatRepositorySupport.java
+++ b/BE/teamgu/src/main/java/com/teamgu/database/repository/ChatRepositorySupport.java
@@ -79,4 +79,26 @@ public class ChatRepositorySupport {
 			em.close();
 		}
 	}
+	
+	/**
+	 * 특정 채팅의 Type을 변경한다
+	 */
+	public boolean changeType(long chat_id,String type) {		
+		EntityManager em = emf.createEntityManager();
+		EntityTransaction et = em.getTransaction();
+		int res = 0;
+		try {
+			String jpql = "UPDATE chat SET type = :type WHERE id = :chat_id";
+			et.begin();
+			res = em.createNativeQuery(jpql).setParameter("type", type).setParameter("chat_id", chat_id).executeUpdate();					
+			et.commit();
+		}catch(Exception e) {
+			et.rollback();
+			log.error("타입 변경에 실패했습니다");
+		}finally {
+			em.close();
+		}
+		if(res>0)return true;
+		return false;
+	}
 }

--- a/BE/teamgu/src/main/java/com/teamgu/database/repository/TeamRepositorySupport.java
+++ b/BE/teamgu/src/main/java/com/teamgu/database/repository/TeamRepositorySupport.java
@@ -33,6 +33,9 @@ import com.teamgu.database.entity.QUser;
 import com.teamgu.database.entity.QUserTeam;
 import com.teamgu.database.entity.Team;
 
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
 @Repository
 public class TeamRepositorySupport {
 
@@ -433,5 +436,28 @@ public class TeamRepositorySupport {
 			return true;
 		else 
 			return false;
+	}
+	/**
+	 * 리더id와 팀id를 대조하여 유효한 초대인지 확인한다	
+	 * 유효하면 양의 정수, 아니라면 0을 반환 
+	 * @param leader_id
+	 * @return
+	 */
+	public boolean checkTeamBetweenLeader(long leader_id,long team_id) {
+		EntityManager em = emf.createEntityManager();
+		try {
+			String jpql = "SELECT IFNULL(id,0) FROM team WHERE id=:team_id AND leader_id=:leader_id\r\n"
+						+ "UNION ALL\r\n"
+						+ "SELECT 0 FROM dual LIMIT 1";
+			List<BigInteger> res = em.createNativeQuery(jpql).setParameter("team_id", team_id).setParameter("leader_id", leader_id).getResultList();
+			long id = res.get(0).longValue();
+			if(id>0)return true;
+		}catch(Exception e) {
+			log.error("팀과 팀장 확인에 실패했습니다");
+			return false;
+		}finally {
+			em.close();
+		}
+		return false;
 	}
 }


### PR DESCRIPTION
**1. 각각의 Type을 함께 관리하기 위한 VO 구현(Type 내용이 수정됐을 때의 수정해야 하는 불편함 감소 및 재사용성 증가)**  

**2. 팀 초대 수락 시 다음의 경우는 수락 실패한다**
   - 초대를 한 대상이 더 이상 리더가 아닌 경우
   - 초대를 한 팀이 더 이상 없는 경우
     - 명시적으로 처리하지는 않았으나 leader와 team을 확인하는 과정에서 오류가 날 것으로 예측
   - 초대를 수락한 대상이 팀 가입이 불가능한 상태인 경우
     - 이미 팀이 있는 경우를 의미
