### PR TITLE
프로필 이미지 업로드 작업을 완성합니다

### DIFF
--- a/FE/components/organisms/Navbar/Navbar.tsx
+++ b/FE/components/organisms/Navbar/Navbar.tsx
@@ -6,6 +6,8 @@ import styled from 'styled-components';
 import { Icon } from '@atoms';
 import { useAuthState, useAppDispatch, setLogout } from '@store';
 import { useScrollPosition } from '@hooks/useWindow';
+import { getImageURL } from '@utils/constants';
+
 const Wrapper = styled.nav<{ isShowByScroll: Boolean }>`
   font-family: 'Roboto', sans-serif;
   position: fixed;
@@ -124,12 +126,12 @@ export default function Navbar(): ReactElement {
   const router = useRouter();
   const { user } = useAuthState();
 
-  const menuRef = useRef();
+  const menuRef = useRef<HTMLDivElement>(null);
   const [show, setShow] = useState(false);
   const [hideOnScroll, setHideOnScroll] = useState(true);
 
   useEffect(() => {
-    const handler = (e: MouseEvent) => {
+    const handler = (e: Event & { target: HTMLDivElement }) => {
       if (!menuRef.current.contains(e.target) && show) {
         setShow(false);
       }
@@ -204,7 +206,7 @@ export default function Navbar(): ReactElement {
         <Image
           className="profileImage"
           alt="프로필사진"
-          src="/profile.png"
+          src={getImageURL(user.img)}
           width={'40%'}
           height={'40%'}
           onClick={() => {

--- a/FE/components/organisms/OtherUserDetail/OtherUserDetail.tsx
+++ b/FE/components/organisms/OtherUserDetail/OtherUserDetail.tsx
@@ -1,10 +1,12 @@
 import { ReactElement, useState, useEffect } from 'react';
 import styled from 'styled-components';
+import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { Icon } from '@atoms';
 import { SkillSelectAutoComplete } from '@molecules';
 import { useAuthState, useAppDispatch, setLoading } from '@store';
 import { getUserDetail } from '@repository/userprofile';
+import { getImageURL } from '@utils/constants';
 
 interface AuthState {
   awards: object[];
@@ -96,11 +98,10 @@ const Manifesto = styled.div`
 
 const Portrait = styled.div`
   width: 100% auto;
-  text-align: center;
-
+  margin-top: 20vh;
+  margin-right: 15px;
   img {
-    width: 70%;
-    margin-top: 15vh;
+    border-radius: 50%;
   }
 `;
 
@@ -269,10 +270,12 @@ export default function OtherUserDetail(): ReactElement {
           <p>{otherUser.introduce}</p>
         </Manifesto>
         <Portrait>
-          <img
+          <Image
             className="default-image"
             alt="프로필이미지"
-            src="/profile.png"
+            src={getImageURL(otherUser.img)}
+            width={500}
+            height={500}
           />
         </Portrait>
       </Introduction>

--- a/FE/components/organisms/UserDetail/MyDetail/Modal/SetImageModal.tsx
+++ b/FE/components/organisms/UserDetail/MyDetail/Modal/SetImageModal.tsx
@@ -62,7 +62,7 @@ export default function RenderCropper({
 }: any) {
   const { user } = useAuthState();
 
-  const inputRef = useRef();
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const triggerFileSelectPopup = () => inputRef?.current?.click();
 
@@ -87,10 +87,15 @@ export default function RenderCropper({
 
   const onClear = () => {
     setImage('/profile.png');
+    setSubmitImage('');
   };
 
   // To upload the edited image
   const onUpload = async () => {
+    if (image === '/profile.png') {
+      changeImageMode();
+      return;
+    }
     const canvas = await getCroppedImg(image, croppedArea);
     const canvasDataUrl = canvas.toDataURL('image/jpeg');
     setImage(canvasDataUrl);

--- a/FE/components/organisms/UserDetail/MyDetail/MyDetail.tsx
+++ b/FE/components/organisms/UserDetail/MyDetail/MyDetail.tsx
@@ -1,8 +1,10 @@
 import { ReactElement } from 'react';
 import styled from 'styled-components';
+import Image from 'next/image';
 import { Icon } from '@atoms';
 import { SkillSelectAutoComplete, Label } from '@molecules';
 import { useAuthState } from '@store';
+import { getImageURL } from '@utils/constants';
 
 interface Project {
   name: string;
@@ -92,12 +94,9 @@ const Manifesto = styled.div`
 
 const Portrait = styled.div`
   width: 100% auto;
-  text-align: center;
-
+  margin-top: 20vh;
+  margin-right: 15px;
   img {
-    width: 70%;
-    margin-top: 15vh;
-    border: 2px solid gray;
     border-radius: 50%;
   }
 `;
@@ -263,10 +262,12 @@ export default function MyDetail({ changeEditMode }: any): ReactElement {
           </div>
         </Manifesto>
         <Portrait>
-          <img
+          <Image
+            src={getImageURL(user.img)}
             className="default-image"
             alt="프로필이미지"
-            src="/profile.png"
+            width={500}
+            height={500}
           />
         </Portrait>
       </Introduction>

--- a/FE/next.config.js
+++ b/FE/next.config.js
@@ -8,6 +8,9 @@ module.exports = {
   eslint: {
     ignoreDuringBuilds: true,
   },
+  images: {
+    domains: ['i5a202.p.ssafy.io'],
+  },
   webpack(config, options) {
     config.resolve = {
       alias: {
@@ -23,7 +26,7 @@ module.exports = {
         '@routes': path.resolve(__dirname, 'routes'),
         '@store': path.resolve(__dirname, 'store'),
         '@styles': path.resolve(__dirname, 'styles'),
-        "@types": path.resolve(__dirname, 'types'),
+        '@types': path.resolve(__dirname, 'types'),
         '@utils': path.resolve(__dirname, 'utils'),
         '@context': path.resolve(__dirname, 'context'),
         '@parse': path.resolve(__dirname, 'test'),

--- a/FE/repository/userprofile.ts
+++ b/FE/repository/userprofile.ts
@@ -42,7 +42,7 @@ export const deleteAward = async (id: number) =>
   });
 
 export const updateDetailInformation = async (param: object) => {
-  await api({
+  return await api({
     url: '/api/auth/userInfo',
     type: 'put',
     param,

--- a/FE/store/authSlice.ts
+++ b/FE/store/authSlice.ts
@@ -63,13 +63,7 @@ const authReducer = createSlice({
       };
     },
     setUserDetail(state, action) {
-      state.user = {
-        ...state.user,
-        wishTrack: action.payload.wishTracks,
-        wishPositionCode: action.payload.wishPosition,
-        introduce: action.payload.introduce,
-        skills: action.payload.skills,
-      };
+      state.user = action.payload;
     },
   },
 });

--- a/FE/utils/constants.ts
+++ b/FE/utils/constants.ts
@@ -50,5 +50,13 @@ export const VIDEO_CHAT_PATH_PREFIX = '/rtc';
 export const CODE_ID = {
   기수: 'ST',
   트랙: 'TR',
-  구분: 'PR'
-}
+  구분: 'PR',
+};
+
+export const getImageURL = (image: string) => {
+  if (image === '' || image === 'null.null') return '/profile.png';
+  return (
+    `https://i5a202.p.ssafy.io:8080/api/file/display?url=profile/${image}#` +
+    new Date().getTime()
+  );
+};

--- a/FE/utils/dataURLtoFile.ts
+++ b/FE/utils/dataURLtoFile.ts
@@ -9,3 +9,12 @@ export const dataURLtoFile = (dataurl: string, filename: string) => {
 
   return new File([u8arr], filename, { type: mime });
 };
+
+export const urltoFile = async (url: string, studentNumber: string) => {
+  const response = await fetch(url);
+  const data = await response.blob();
+  const ext = url.split('.').pop(); // url 구조에 맞게 수정할 것
+  const filename = `${studentNumber}_profile.${ext}`; // url 구조에 맞게 수정할 것
+  const metadata = { type: `image/${ext}` };
+  return new File([data], filename!, metadata);
+};


### PR DESCRIPTION
> Resolve [#S05P13A202-307](https://jira.ssafy.com/browse/S05P13A202-307)

### 어려움을 느껴던 지점
1. 이미지의 형식이 총 3가지였습니다. (File 형식, 일반 url 형식, data url 형식) 서버에 보내게 되는 것은 File 형식, 프리뷰에 사용하게 되는 것은 data url 형식, 실제 파일을 불러오는 과정은 일반 url 형식이었습니다. 때문의 각각의 컴포넌트에서 사용해야 하는 이미지의 형식일 달라서 애를 먹었습니다. 
8c5876a 또한 각각의 형태에서 다른 형태로의 전환이 가능하고 해당 함수를 찾아서 사용하였습니다.

2. 이미지의 uri가 같은 경우 이미지가 재로딩 되지 않습니다. 현재 저희의 경우 이미지를 업로드하게 되면 기존의 이미지 파일을 제거하고 똑같은 이름의 새로운 이미지 파일을 만들어내는 형식이었습니다.
https://github.com/facebook/react-native/issues/12606 하지만, 이는 문제가 있는데 리액트 자체에서 이 변화를 감지하지 못한다는 것과 해당 이미지가 캐싱된다는 것이었습니다. 때문에 조금 다른 방법이 필요했는데 바로 #과 뒤에 임의의 값을 붙이는 방식입니다. 
2a61094 해당 방식으로 해야지 브라우저가 해당 이미지를 캐싱하지 않습니다. 

실제 적용은 이런 식으로 하시면 될 것 같습니다. f7b8b94
```javascript
import { getImageURL } from '@utils/constants';

  <Image
            className="profile"
            alt="프로필이미지"
            src={getImageURL(otherUser.img)}
            width={}
            height={}
          />
```