### PR TITLE
채팅방의 기능 수정 및 추가

### DIFF
--- a/BE/teamgu/src/main/java/com/teamgu/api/controller/StompChatController.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/controller/StompChatController.java
@@ -89,7 +89,7 @@ public class StompChatController {
 	@MessageMapping(value="/chat/messageRTC")
 	public void messageRTC(@RequestBody UserRoomInviteReqDto userReqDto) {
 		log.info("in user-invite...");
-		log.info(userReqDto.getUser_id()+"가 "+userReqDto.getRoom_id()+" 방에 메세지를 보냅ㄴ디ㅏ");
+		log.info(userReqDto.getUser_id()+"가 "+userReqDto.getRoom_id()+" 방에 메세지를 보냅니다.");
 		long roomid = userReqDto.getRoom_id();
 		String name = userService.getUserById(userReqDto.getUser_id()).get().getName();
 		//1. 초대 메세지 보내기 전에 저장
@@ -130,11 +130,13 @@ public class StompChatController {
 		log.info(leader_id+"가 "+invitee_id+"를"+team_id+" 팀으로 초대합니다");
 		
 		//1. 해당 유저와 채팅방이 생성되어 있는지 체크하고 없다면 생성한다
-		long chat_room_id = chatService.roomCheck(leader_id, invitee_id);
+		long chat_room_id = chatService.roomCheckOneToOne(leader_id, invitee_id);
+		
 		if(chat_room_id==0) {//존재하지 않는 경우 방을 생성하고 방 번호를 반환한다.
 //			String name1 = userService.getUserById(leader_id).get().getName(); //name변수와 동일한 처리이므로 주석처리
 			String name2 = userService.getUserById(invitee_id).get().getName();			
-			ChatRoomResDto chatRoomResDto = chatService.createRoom(name+", "+name2+"의 방");
+			String init_title = name+", "+name2+"의 방";	//초기 채팅방 이름
+			ChatRoomResDto chatRoomResDto = chatService.createRoom(init_title);
 			chat_room_id = chatRoomResDto.getChat_room_id();
 			
 			log.info(chat_room_id+"방이 생성되었습니다");

--- a/BE/teamgu/src/main/java/com/teamgu/api/dto/req/ChatRoomModifyReqDto.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/dto/req/ChatRoomModifyReqDto.java
@@ -17,4 +17,6 @@ public class ChatRoomModifyReqDto {
 	String title;
 	@ApiModelProperty(name = "변경하고 싶은 채팅방의 id")
 	long room_id;
+	@ApiModelProperty(name = "변경을 요청한 유저의 id")
+	long user_id;
 }

--- a/BE/teamgu/src/main/java/com/teamgu/api/service/ChatService.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/service/ChatService.java
@@ -33,7 +33,7 @@ public interface ChatService {
 	 * 있다면 양의정수를, 그렇지 않다면 0을 반환한다
 	 * 1:1 대화 전용
 	 */
-	long roomCheck(long my_user_id, long you_user_id);
+	long roomCheckOneToOne(long my_user_id, long you_user_id);
 	
 	/**
 	 * 새로운 채팅방을 생성하고 새롭게 생성된 채팅방 ID를 반환한다.
@@ -41,16 +41,18 @@ public interface ChatService {
 	ChatRoomResDto createRoom(String title);
 	
 	/**
-	 * 특정 채팅방에 인원을 초대한다
+	 * 특정 채팅방(단톡)에 인원을 초대한다
 	 */
 	boolean inviteUser(long user_id,long room_id);
 	
 	/**
-	 * N명(본인포함)의 인원으로 채팅방을 개설한다.
-	 * 즉, 인원의 이름을 creatRoom에 넘겨주고 방을 생성한다.
-	 * 이후 user_chat_room에 해당 인원을 추가한다.
+	 * 개인톡에 인원을 최초로 초대하는 과정, title은 반드시 상대방의 이름이어야 한다
+	 * @param user_id
+	 * @param room_id
+	 * @param title
+	 * @return
 	 */
-	
+	boolean inviteUserPersonalRoom(long user_id,long room_id, String title);
 	
 	/**
 	 * 채팅 메세지를 DB에 저장한다
@@ -110,7 +112,7 @@ public interface ChatService {
 	 * @param room_id
 	 * @return
 	 */
-	boolean inviteNUsers(List<Long> users, long room_id);
+	boolean inviteNUsers(List<Long> users, long room_id, String title);
 	
 	/**
 	 * 개인이 특정 채팅방을 나간다
@@ -118,12 +120,13 @@ public interface ChatService {
 	boolean leaveRoom(long room_id,long user_id);
 	
 	/**
-	 * 방 이름을 변경한다
+	 * 특정 유저의 선택한 방 이름을 변경한다
 	 * @param title
 	 * @param room_id
+	 * @paran user_id
 	 * @return
 	 */
-	boolean modifyRoomName(String title, long room_id);
+	boolean modifyRoomName(String title, long room_id, long user_id);
 	
 	/**
 	 * 특정 채팅방에 속해있는 유저의 id를 반환한다

--- a/BE/teamgu/src/main/java/com/teamgu/api/service/ChatServiceImpl.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/service/ChatServiceImpl.java
@@ -80,7 +80,7 @@ public class ChatServiceImpl implements ChatService{
 			//해당 목록에서 필요한 정보를 DtoList에 저장한다.
 			ChatRoomResDto crrd = ChatRoomResDto.builder()
 												.chat_room_id(chatroomid)
-												.room_name(chatRoomRepository.findById(chatroomid).get().getTitle())
+												.room_name(userChatRoom.getTitle())//개인이 설정한 채팅방명을 가져온다
 												.last_chat_message(lastchat.getMessage())//해당 채팅방의 마지막 메세지를 가져온다.
 												.send_date_time(lastchat.getSendDateTime())//해당 채팅방의 마지막 전송 시간을 가져온다.
 												.out_check_chat_id(last_chat_id)//마지막 채팅 id
@@ -111,14 +111,17 @@ public class ChatServiceImpl implements ChatService{
 	@Override
 	public List<ChatMessageResDto> getChatMessageList(long chatRoomId) {
 		List<ChatMessageResDto> chatMessageResDtoList = new ArrayList<ChatMessageResDto>();
-		for(Chat chat:chatRepositorySupport.findByReceiveRoomId(chatRoomId)) {			
+		for(Chat chat:chatRepositorySupport.findByReceiveRoomId(chatRoomId)) {
+			long team_id = 0;
+			if(!chat.getType().contains("TEAM_INVITE"))//팀초대 관련 메세지만 team_id를 가져온다
+				team_id = chat.getTeamId();
 			ChatMessageResDto chatMessageResDto = ChatMessageResDto.builder()
 													.chat_id(chat.getId())
 													.message(chat.getMessage())
 													.sender_id(chat.getUser().getId())
 													.sender_name(chat.getUser().getName())
 													.type(chat.getType())
-													.team_id(chat.getTeamId())
+													.team_id(team_id)
 													.create_date_time(chat.getSendDateTime())
 													.unread_user_count(0)//읽지 않은 유저를 관리해야한다
 													.build();
@@ -133,11 +136,6 @@ public class ChatServiceImpl implements ChatService{
 		log.info("in saveChat method...");
 		log.info("roomid : "+chatReqDto.getRoom_id()+" sender_id : "+chatReqDto.getSender_id());
 		LocalDateTime created_time = LocalDateTime.now();
-		//Mapper 오류로 인한 주석처리. Setter로 대체한다
-//		Chat chat = ChatMapper.INSTANCE.reqDtoToEntity(ChatReqDto.builder()
-//														.message(chatReqDto.getMessage())
-//														.type(chatReqDto.getType())
-//														.build());
 		Chat chat = new Chat();
 		chat.setMessage(chatReqDto.getMessage());
 		if(chatReqDto.getType()==null || chatReqDto.getType().equals(""))
@@ -174,18 +172,16 @@ public class ChatServiceImpl implements ChatService{
 	}
 	
 	@Override
-	public long roomCheck(long my_user_id, long you_user_id) {
+	public long roomCheckOneToOne(long my_user_id, long you_user_id) {
 		return userChatRoomRepositorySupport.findCommonRoom(my_user_id, you_user_id);
 	}
 	
 	@Override
 	public boolean inviteUser(long user_id, long room_id) {
 		log.info(user_id+" 유저를 "+room_id+" 방으로 초대합니다");	
-		String user_name = userRepository.findById(user_id).get().getName();
-		String room_name = chatRoomRepository.findById(room_id).get().getTitle();
-		String new_room_name = room_name.replace("의 방",", "+user_name+"의 방");
-		log.info("유저의 이름을 추가하여 바뀐 방 이름 : "+new_room_name);
-		return userChatRoomRepositorySupport.insertUser(user_id, room_id, new_room_name);
+		ChatRoom chatRoom = chatRoomRepository.findById(room_id).get();
+		String room_name = chatRoom.getTitle();
+		return userChatRoomRepositorySupport.insertUser(user_id, room_id,room_name);
 	}
 	
 	@Override
@@ -225,8 +221,8 @@ public class ChatServiceImpl implements ChatService{
 	}
 	
 	@Override
-	public boolean inviteNUsers(List<Long> users, long room_id) {
-		return chatRoomRepositorySupport.inviteNUsers(users, room_id);
+	public boolean inviteNUsers(List<Long> users, long room_id, String title) {
+		return chatRoomRepositorySupport.inviteNUsers(users, room_id,title);
 	}
 	
 	@Override
@@ -235,12 +231,18 @@ public class ChatServiceImpl implements ChatService{
 	}
 	
 	@Override
-	public boolean modifyRoomName(String title, long room_id) {		
-		return chatRoomRepositorySupport.modifyRoomName(title, room_id);
+	public boolean modifyRoomName(String title, long room_id, long user_id) {		
+		return chatRoomRepositorySupport.modifyPersonalRoomName(title, room_id,user_id);
 	}	
 	
 	@Override
 	public boolean changeType(long chat_id, String type) {
 		return chatRepositorySupport.changeType(chat_id, type);
+	}
+	
+	@Override
+	public boolean inviteUserPersonalRoom(long user_id, long room_id, String title) {
+		log.info(user_id+" 유저를 "+room_id+" 개인 톡방으로 초대합니다");	
+		return userChatRoomRepositorySupport.insertUser(user_id, room_id, title);
 	}
 }

--- a/BE/teamgu/src/main/java/com/teamgu/database/entity/UserChatRoom.java
+++ b/BE/teamgu/src/main/java/com/teamgu/database/entity/UserChatRoom.java
@@ -21,6 +21,8 @@ import lombok.Setter;
 @Setter
 @IdClass(UserChatRoomPK.class)
 public class UserChatRoom{	
+	String title;
+	
 	@Id
 	@ManyToOne
 	@JoinColumn(name = "userId")
@@ -33,5 +35,5 @@ public class UserChatRoom{
 	
 	@ManyToOne
 	@JoinColumn(name = "lastChatId")
-	Chat chat;
+	Chat chat;	
 }

--- a/BE/teamgu/src/main/java/com/teamgu/database/repository/ChatRoomRepositorySupport.java
+++ b/BE/teamgu/src/main/java/com/teamgu/database/repository/ChatRoomRepositorySupport.java
@@ -148,10 +148,10 @@ public class ChatRoomRepositorySupport {
 				long user_id = users.get(i);
 				if(i==0) jpql+="\r\nVALUES";			
 				if(i>0) jpql+=",";
-				jpql+="\r\n("+room_id+","+user_id+",null,"+title+")";
+				jpql+="\r\n("+room_id+","+user_id+",null,:title)";
 			}			
 			log.debug(jpql);
-			em.createNativeQuery(jpql).executeUpdate();
+			em.createNativeQuery(jpql).setParameter("title", title).executeUpdate();
 			et.commit();
 		}catch(Exception e) {
 			log.error("N명 방 생성에 실패");
@@ -182,10 +182,10 @@ public class ChatRoomRepositorySupport {
 				long user_id = users.get(i);
 				if(i==0) jpql+="\r\nVALUES";			
 				if(i>0) jpql+=",";
-				jpql+="\r\n("+room_id+","+user_id+",null,"+title+")";
+				jpql+="\r\n("+room_id+","+user_id+",null,:title)";
 			}			
 			log.debug(jpql);
-			em.createNativeQuery(jpql).executeUpdate();
+			em.createNativeQuery(jpql).setParameter("title", title).executeUpdate();
 			et.commit();
 		}catch(Exception e) {
 			log.error("N명 대화방 초대에 실패했습니다");

--- a/BE/teamgu/src/main/java/com/teamgu/database/repository/UserChatRoomRepositorySupport.java
+++ b/BE/teamgu/src/main/java/com/teamgu/database/repository/UserChatRoomRepositorySupport.java
@@ -63,27 +63,29 @@ public class UserChatRoomRepositorySupport {
 		return ucrList.get(0).longValue();
 	}
 	/**
-	 * 기존의 방에 새로운 유저를 초대한다 그리고 채팅방 명에 유저를 추가한다
+	 * 채팅방에 유저를 초대한다
 	 * @param user_id
 	 * @param room_id
 	 */
-	public boolean insertUser(long user_id,long room_id, String new_room_name) {
+	public boolean insertUser(long user_id,long room_id, String title) {
 		EntityManager em = emf.createEntityManager();
 		EntityTransaction et = em.getTransaction();
 		try {
 			et.begin();
-			String jpql = "INSERT INTO user_chat_room(chat_room_id,user_id) "
-						+ "VALUES(?1,?2)";
+			//초대 되는 유저는 title이 없기 때문에 기존 title을 적용시켜준다
+			String jpql = "INSERT INTO user_chat_room(chat_room_id,user_id,title) "
+						+ "VALUES(?1,?2,?3)";
 			em.createNativeQuery(jpql)
 				.setParameter(1, room_id)
 				.setParameter(2, user_id)
+				.setParameter(3, title)
 				.executeUpdate();
 			
-			jpql ="UPDATE chat_room SET title = :new_room_name WHERE id = :room_id";
-			em.createNativeQuery(jpql)
-				.setParameter("new_room_name", new_room_name)
-				.setParameter("room_id", room_id)
-				.executeUpdate();
+//			jpql ="UPDATE chat_room SET title = :new_room_name WHERE id = :room_id";
+//			em.createNativeQuery(jpql)
+//				.setParameter("new_room_name", new_room_name)
+//				.setParameter("room_id", room_id)
+//				.executeUpdate();
 			et.commit();
 			return true;
 		}catch(Exception e) {


### PR DESCRIPTION
- 각 채팅방 별 채팅방 이름이 각 유저별로 따로 관리됩니다
- 위의 기능을 사용하기 위해 `UserChatRoom Entity`에 `Title` 컬럼이 추가되었습니다.
- 개인톡이 생성될 시 상대방의 이름으로 채팅방 이름이 설정됩니다
- 단체톡이 생성될 시 초대된 모든 유저의 이름으로 채팅방 이름이 설정됩니다
- 새로운 유저가 단체톡방에 참여하게 됐을때 더 이상 채팅방 이름에 영향을 미치지 않습니다

_테스트를 위해 채팅 관련 DB를 모두 delete 하였습니다._