### PR TITLE
비밀번호 변경 모달 생성

### DIFF
--- a/FE/components/atoms/Input/Input.tsx
+++ b/FE/components/atoms/Input/Input.tsx
@@ -25,6 +25,7 @@ interface InputProps {
   value?: string;
   refValue?: string;
   accept?: string;
+  autoComplete?: string;
 }
 
 const Wrapper = styled.div<{
@@ -76,6 +77,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
       value,
       refValue = '',
       accept = '',
+      autoComplete = 'on',
     }: InputProps,
     ref,
   ): ReactElement => {
@@ -111,6 +113,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
           value={value}
           onKeyDown={onKeyDown}
           accept={accept}
+          autoComplete={autoComplete}
         />
         {error?.split('/')[0] !== '' && <div>{error?.split('/')[0]}</div>}
       </Wrapper>

--- a/FE/components/organisms/Modal/Modal.tsx
+++ b/FE/components/organisms/Modal/Modal.tsx
@@ -4,7 +4,11 @@ import { MODALS } from '@utils/constants';
 import ModalWrapper from './ModalWrapper';
 import AlertModal from './AlertModal';
 import HocModal from './HocModal';
-import { ProjectModal, AwardModal } from '../UserDetail/MyDetail/Modal';
+import {
+  ProjectModal,
+  AwardModal,
+  ChangePasswordModal,
+} from '../UserDetail/MyDetail/Modal';
 
 interface ModalProps {
   modalName: string;
@@ -27,6 +31,7 @@ export default function Modal({
               [MODALS.PROJECT_MODAL]: <ProjectModal />,
               [MODALS.AWARD_MODAL]: <AwardModal />,
               [MODALS.HOC_MODAL]: <HocModal>{children}</HocModal>,
+              [MODALS.CHANGEPASSWORD_MODAL]: <ChangePasswordModal />,
             }[modalName]
           }
         </ModalWrapper>

--- a/FE/components/organisms/UserDetail/MyDetail/Modal/ChangePasswordModal.tsx
+++ b/FE/components/organisms/UserDetail/MyDetail/Modal/ChangePasswordModal.tsx
@@ -1,0 +1,163 @@
+import { ReactElement, SyntheticEvent, useState, useRef } from 'react';
+import styled from 'styled-components';
+import { Input } from '@atoms';
+import { Button } from '@molecules';
+import { changePassword } from '@repository/userprofile';
+import { useAuthState, useAppDispatch, removeModal } from '@store';
+import { MODALS } from '@utils/constants';
+
+const Wrapper = styled.div`
+  margin: 30px;
+`;
+
+const ChangePW = styled.div`
+  div {
+    margin-bottom: 15px;
+
+    button {
+      width: 5vw;
+      height: 20px;
+      margin-left: 5px;
+    }
+  }
+`;
+
+const Error = styled.div`
+  font-weight: 900;
+  color: red;
+`;
+
+export default function ChangePasswordModal(): ReactElement {
+  const { user } = useAuthState();
+  const dispatch = useAppDispatch();
+
+  const [error, setError] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const emailRef = useRef<HTMLInputElement>(null);
+  const passwordRef = useRef<HTMLInputElement>(null);
+  const newPasswordRef = useRef<HTMLInputElement>(null);
+  const confirmNewPasswordRef = useRef<HTMLInputElement>(null);
+
+  const handlePassword = async (e: SyntheticEvent) => {
+    e.preventDefault();
+    if (
+      !emailRef?.current?.value ||
+      !passwordRef?.current?.value ||
+      !newPasswordRef?.current?.value ||
+      !confirmNewPasswordRef?.current?.value
+    ) {
+      setErrorMessage('모든 값을 입력해주세요.');
+      setError(true);
+      return;
+    }
+    if (emailRef?.current?.value !== user.email) {
+      setErrorMessage('이메일이 다릅니다.');
+      setError(true);
+      return;
+    }
+    const re =
+      /^(?=.*[a-zA-z])(?=.*[0-9])(?=.*[$`~!@$!%*#^?&\\(\\)\-_=+]).{8,16}$/;
+    if (!re.test(newPasswordRef?.current?.value)) {
+      setErrorMessage(
+        '숫자, 영문, 특수문자 각 1자리 이상, 8자-16자 사이를 입력해주세요.',
+      );
+      setError(true);
+      return;
+    }
+    if (newPasswordRef?.current?.value !== passwordRef?.current?.value) {
+      setErrorMessage('새로운 비밀번호를 입력해주세요.');
+      setError(true);
+      return;
+    }
+    if (
+      newPasswordRef?.current?.value !== confirmNewPasswordRef?.current?.value
+    ) {
+      setErrorMessage('변경하실 비밀번호를 올바르게 입력해주세요.');
+      setError(true);
+      return;
+    }
+    try {
+      const data = {
+        email: emailRef?.current?.value,
+        modPassword: newPasswordRef?.current?.value,
+        oriPassword: passwordRef.current.value,
+      };
+      await changePassword(data);
+      alert('비밀번호가 정상적으로 변경되었습니다.');
+      dispatch(removeModal({ modalName: MODALS.CHANGEPASSWORD_MODAL }));
+    } catch (e) {
+      console.log(e);
+      setErrorMessage('비밀번호가 틀립니다.');
+      setError(true);
+    }
+  };
+
+  return (
+    <Wrapper>
+      <form onSubmit={handlePassword}>
+        <ChangePW>
+          <div>
+            <div style={{ display: 'none' }}>
+              <Input aria-hidden="true" />
+              <Input type="password" aria-hidden="true" />
+            </div>
+            <Input
+              placeHolder={'이메일을 입력해주세요.'}
+              width="30vw"
+              height="50px"
+              ref={emailRef}
+              maxLength={20}
+              autoComplete="off"
+            />
+          </div>
+          <div>
+            <Input
+              placeHolder={'기존 비밀번호를 입력해주세요.'}
+              type="password"
+              width="30vw"
+              height="50px"
+              ref={passwordRef}
+              maxLength={16}
+              autoComplete="off"
+            />
+          </div>
+          <div>
+            <Input
+              placeHolder={'새로운 비밀번호를 입력해주세요.'}
+              type="password"
+              width="30vw"
+              height="50px"
+              ref={newPasswordRef}
+              maxLength={16}
+              autoComplete="off"
+            />
+          </div>
+          <div>
+            <Input
+              placeHolder={'새로운 비밀번호를 다시 한 번 입력해주세요.'}
+              type="password"
+              width="30vw"
+              height="50px"
+              ref={confirmNewPasswordRef}
+              maxLength={16}
+              autoComplete="off"
+            />
+          </div>
+          {error && <Error>{errorMessage}</Error>}
+          <div>
+            <Button title="생성" type="submit" />
+            <Button
+              title="닫기"
+              func={() =>
+                dispatch(
+                  removeModal({ modalName: MODALS.CHANGEPASSWORD_MODAL }),
+                )
+              }
+            />
+          </div>
+        </ChangePW>
+      </form>
+    </Wrapper>
+  );
+}

--- a/FE/components/organisms/UserDetail/MyDetail/Modal/index.ts
+++ b/FE/components/organisms/UserDetail/MyDetail/Modal/index.ts
@@ -1,4 +1,5 @@
 import AwardModal from './AwardModal';
 import ProjectModal from './ProjectModal';
+import ChangePasswordModal from './ChangePasswordModal';
 
-export { AwardModal, ProjectModal };
+export { AwardModal, ProjectModal, ChangePasswordModal };

--- a/FE/components/organisms/UserDetail/MyDetail/MyDetailEdit.tsx
+++ b/FE/components/organisms/UserDetail/MyDetail/MyDetailEdit.tsx
@@ -439,7 +439,19 @@ export default function MyDetailEdit({ changeEditMode }: any): ReactElement {
           />
         </ModalWrapper>
       )}
+
       <Icons>
+        <Icon
+          iconName="password"
+          color="black"
+          func={() =>
+            dispatch(
+              displayModal({
+                modalName: MODALS.CHANGEPASSWORD_MODAL,
+              }),
+            )
+          }
+        />
         <Icon iconName="clear" color="black" func={changeEditMode} />
       </Icons>
       <form onSubmit={onSubmit} encType="multipart/form-data">

--- a/FE/repository/userprofile.ts
+++ b/FE/repository/userprofile.ts
@@ -62,3 +62,11 @@ export const getUserDetailbyRefresh = async () => {
     type: 'get',
   });
 };
+
+export const changePassword = async (param: object) => {
+  await api({
+    url: '/api/auth/password',
+    type: 'put',
+    param,
+  });
+};

--- a/FE/store/modalSlice.ts
+++ b/FE/store/modalSlice.ts
@@ -7,6 +7,7 @@ interface ModalState {
   [MODALS.PROJECT_MODAL]: boolean;
   [MODALS.AWARD_MODAL]: boolean;
   [MODALS.HOC_MODAL]: boolean;
+  [MODALS.CHANGEPASSWORD_MODAL]: boolean;
   content?: any;
 }
 
@@ -15,6 +16,7 @@ const initialState: ModalState = {
   [MODALS.PROJECT_MODAL]: false,
   [MODALS.AWARD_MODAL]: false,
   [MODALS.HOC_MODAL]: false,
+  [MODALS.CHANGEPASSWORD_MODAL]: false,
   content: '',
 };
 

--- a/FE/utils/constants.ts
+++ b/FE/utils/constants.ts
@@ -3,11 +3,13 @@ export const MODALS: {
   PROJECT_MODAL: string;
   AWARD_MODAL: string;
   HOC_MODAL: string;
+  CHANGEPASSWORD_MODAL: string;
 } = {
   ALERT_MODAL: 'alertModal',
   PROJECT_MODAL: 'projectModal',
   AWARD_MODAL: 'awardModal',
   HOC_MODAL: 'hocModal',
+  CHANGEPASSWORD_MODAL: 'changePasswordModal',
 };
 
 export const PROJECT_CODE: any = {


### PR DESCRIPTION
> Resolve [#S05P13A202-147](https://jira.ssafy.com/browse/S05P13A202-147)

비밀번호 변경 모달을 생성합니다. 가장 어려웠던 부분은 이메일과 비밀번호에 대한 자동완성을 끄는 것이었습니다. input의 autoComplete만 끄면 더이상 나타나지 않을 줄 알았는데 직접 해보니까 계속해서 이미 값이 넣어져 있는 상태였습니다. 알아보니 브라우저 자체에서 지원하는 기능이 또 추가로 있었습니다.

[참고한글](https://chanspark.github.io/2017/07/13/%ED%81%AC%EB%A1%AC-%EC%9E%90%EB%8F%99%EC%99%84%EC%84%B1-%EA%B8%B0%EB%8A%A5-%EC%A0%9C%EA%B1%B0%ED%95%98%EA%B8%B0.html)
해당 글을 참조하여 더미 input을 두었고 이를 통해 자동완성을 막았습니다.
