### PR TITLE
팀페이지 이미지 경로 백엔드 구현 전까지 주석처리

### DIFF
--- a/FE/components/organisms/TeamStatusCard/TeamStatusCard.tsx
+++ b/FE/components/organisms/TeamStatusCard/TeamStatusCard.tsx
@@ -4,6 +4,7 @@ import { Text, Icon } from '@atoms';
 import { Tag, ProfileImage } from '@molecules';
 import { useAuthState } from '@store';
 import { Team } from '@utils/type';
+import { getImageURL } from '@utils/constants';
 
 const Wrapper = styled.div<{ isComplete: boolean }>`
   position: relative;
@@ -120,7 +121,7 @@ export default function TeamStatusCard({
                 <div className="profile" key={item.id}>
                   <ProfileImage
                     size={80}
-                    src={item.img ? item.img : undefined}
+                    // src={item.img ? getImageURL(item.img) : undefined}
                   />
                   {item.id === team.leaderId ? (
                     <Text text={item.name + '(팀장)'} />


### PR DESCRIPTION
팀 페이지에서 주는 이미지경로는 아직 구현되어있지 않기 때문에, 주석처리 합니다.
그렇지 않으면 팀 페이지가 보여지지 않습니다.