### PR TITLE
feat: 관리자의 교육생 관리 조회, 반 Select Box 조회

### DIFF
--- a/BE/teamgu/src/main/java/com/teamgu/api/controller/AdminController.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/controller/AdminController.java
@@ -15,9 +15,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.teamgu.api.dto.req.AdminTeamManagementReqDto;
+import com.teamgu.api.dto.req.AdminManagementReqDto;
 import com.teamgu.api.dto.req.ProjectCodeReqDto;
 import com.teamgu.api.dto.res.AdminTeamManagementResDto;
+import com.teamgu.api.dto.res.AdminUserManagementResDto;
 import com.teamgu.api.dto.res.BasicResponse;
 import com.teamgu.api.dto.res.CodeResDto;
 import com.teamgu.api.dto.res.CommonResponse;
@@ -150,7 +151,7 @@ public class AdminController {
 	@GetMapping("/dashboard/{projectId}")
 	public ResponseEntity<? extends BasicResponse> getTeamBuildingStatus(@PathVariable Long projectId) {
 
-		if(!adminService.checkProjectDeletion(projectId)) {
+		if(adminService.checkProjectValidation(projectId)) { // 존재하는 프로젝트일 경우
 
 			DashBoardResDto dashBoard = adminService.getTeamBuildingStatus(projectId);
 			
@@ -164,7 +165,7 @@ public class AdminController {
 	@GetMapping("/dashboardtable/{projectId}")
 	public ResponseEntity<? extends BasicResponse> getTeamBuildingTable(@PathVariable Long projectId) {
 
-		if(!adminService.checkProjectDeletion(projectId)) {
+		if(adminService.checkProjectValidation(projectId)) { // 존재하는 프로젝트일 경우
 
 			List<DashBoardTableResDto> dashBoardTable = adminService.getDashBoardTableInfo(projectId);
 			
@@ -176,12 +177,12 @@ public class AdminController {
 	
 	@ApiOperation(value = "팀 구성 현황 조회")
 	@PostMapping("/team")
-	public ResponseEntity<? extends BasicResponse> getTeamManagementData(@RequestBody AdminTeamManagementReqDto adminTeamManagementReqDto){
+	public ResponseEntity<? extends BasicResponse> getTeamManagementData(@RequestBody AdminManagementReqDto adminTeamManagementReqDto){
 		
 		Long projectId = adminTeamManagementReqDto.getProjectId();
 		int regionCode = adminTeamManagementReqDto.getRegionCode();
 		
-		if(!adminService.checkProjectDeletion(projectId)) {
+		if(adminService.checkProjectValidation(projectId)) { // 존재하는 프로젝트일 경우
 			List<AdminTeamManagementResDto> list = adminService.getTeamManagementData(projectId, regionCode);
 			
 			return ResponseEntity.ok(new CommonResponse<List<AdminTeamManagementResDto>>(list));
@@ -192,5 +193,42 @@ public class AdminController {
 				.body(new ErrorResponse("존재하지 않는 프로젝트입니다"));
 		
 	}
+	
+	@ApiOperation(value = "회원 관리 조회")
+	@PostMapping("/user")
+	public ResponseEntity<? extends BasicResponse> getUserManagamentData(@RequestBody AdminManagementReqDto adminUserManagementReqDto){
 
+		Long projectId = adminUserManagementReqDto.getProjectId();
+		int regionCode = adminUserManagementReqDto.getRegionCode();
+		
+		if(adminService.checkProjectValidation(projectId)) { // 존재하는 프로젝트일 경우
+			
+			List<AdminUserManagementResDto> list = adminService.getUserManagamentData(projectId, regionCode);
+			return ResponseEntity.ok(new CommonResponse<List<AdminUserManagementResDto>>(list));
+
+		}
+		
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+				.body(new ErrorResponse("존재하지 않는 프로젝트입니다"));
+		
+	}
+	
+	@ApiOperation(value = "Class Select Box 조회")
+	@PostMapping("/user/class")
+	public ResponseEntity<? extends BasicResponse> getClassCode(@RequestBody AdminManagementReqDto adminUserManagementReqDto){
+
+		Long projectId = adminUserManagementReqDto.getProjectId();
+		int regionCode = adminUserManagementReqDto.getRegionCode();
+		
+		if(adminService.checkProjectValidation(projectId)) { // 존재하는 프로젝트일 경우
+			
+			List<CodeResDto> list = adminService.getClassCode(projectId, regionCode);
+			return ResponseEntity.ok(new CommonResponse<List<CodeResDto>>(list));
+
+		}
+		
+		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+				.body(new ErrorResponse("존재하지 않는 프로젝트입니다"));
+		
+	}
 }

--- a/BE/teamgu/src/main/java/com/teamgu/api/dto/req/AdminManagementReqDto.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/dto/req/AdminManagementReqDto.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 @Getter
 @ApiModel(description = "Admin Team Building Status Management Reqeust Model ")
-public class AdminTeamManagementReqDto {
+public class AdminManagementReqDto {
 	
 	@ApiModelProperty(name = "project_detail Id", example = "1")
 	Long projectId;

--- a/BE/teamgu/src/main/java/com/teamgu/api/dto/res/AdminUserManagementResDto.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/dto/res/AdminUserManagementResDto.java
@@ -1,0 +1,50 @@
+package com.teamgu.api.dto.res;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ApiModel(description = "Admin User Status Response Model")
+public class AdminUserManagementResDto {
+
+	@ApiModelProperty(name = "학번", example = "0540000")
+	String studentNumber;
+
+	@ApiModelProperty(name = "이름", example = "김싸피")
+	String name;
+
+	@ApiModelProperty(name = "지역", example = "서울")
+	String region;
+
+	@ApiModelProperty(name = "반", example = "서울 2반")
+	String studentClass;
+
+	@ApiModelProperty(name = "교육생/퇴소생", example = "교육생")
+	String role;
+
+	@ApiModelProperty(name = "전공/비전공", example = "전공")
+	String major;
+
+	@ApiModelProperty(name = "프로젝트 참여/제외", example = "등록")
+	String regist;
+	
+	@ApiModelProperty(name = "팀 구성 여부", example = "O")
+	String completeYn;
+
+	@ApiModelProperty(name = "팀 고유 번호", example = "1")
+	String teamId;
+
+	@ApiModelProperty(name = "팀 이름", example = "teamgu")
+	String teamName;
+
+	@ApiModelProperty(name = "트랙 이름", example = "웹 기술")
+	String trackName;
+
+}

--- a/BE/teamgu/src/main/java/com/teamgu/api/service/AdminService.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/service/AdminService.java
@@ -3,11 +3,16 @@ package com.teamgu.api.service;
 import java.util.List;
 
 import com.teamgu.api.dto.res.AdminTeamManagementResDto;
+import com.teamgu.api.dto.res.AdminUserManagementResDto;
 import com.teamgu.api.dto.res.CodeResDto;
 import com.teamgu.api.dto.res.DashBoardResDto;
 import com.teamgu.api.dto.res.DashBoardTableResDto;
 import com.teamgu.api.dto.res.ProjectInfoResDto;
 
+/**
+ * @author naann
+ *
+ */
 public interface AdminService {
 	
 	/**
@@ -101,6 +106,16 @@ public interface AdminService {
 	 * @return
 	 */
 	public boolean checkProjectDeletion(Long projectId);
+
+	
+	/**
+	 * Check Project Validation
+	 * 프로젝트의 유효성을 체크한다. 존재하는 프로젝트이면 true를 없으면 false를 반환한다.
+	 * project Id기반 관리자의 데이터 조회시 유효한 프로젝트임을 검증할 때 쓰인다.
+	 * @param projectId
+	 * @return
+	 */
+	public boolean checkProjectValidation(Long projectId);
 	
 	/**
 	 * Select DashBoard Data
@@ -129,4 +144,22 @@ public interface AdminService {
 	 */
 	public List<AdminTeamManagementResDto> getTeamManagementData(Long projectId, int regionCode);
 	
+	/**
+	 * Select User Status to manage , import, regist
+	 * Project Id와 region code를 통해 회원 현황을 조회하여 관리한다
+	 * @param projectId
+	 * @param regionCode
+	 * @return
+	 */
+	public List<AdminUserManagementResDto> getUserManagamentData(Long projectId, int regionCode);
+
+	/**
+	 * Get Class Select Box
+	 * 프로젝트별 회원 정보 관리 탭의 반 메뉴를 구성한다. 
+	 * region code가 0이 아니라면 지역별로도 필터 할수 있도록 한다.
+	 * @param projectId
+	 * @param regionCode
+	 * @return
+	 */
+	public List<CodeResDto> getClassCode(Long projectId, int regionCode);
 }

--- a/BE/teamgu/src/main/java/com/teamgu/api/service/AdminServiceImpl.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/service/AdminServiceImpl.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import com.teamgu.api.dto.res.AdminTeamManagementResDto;
+import com.teamgu.api.dto.res.AdminUserManagementResDto;
 import com.teamgu.api.dto.res.CodeResDto;
 import com.teamgu.api.dto.res.DashBoardDetailInfoResDto;
 import com.teamgu.api.dto.res.DashBoardDetailResDto;
@@ -315,6 +316,19 @@ public class AdminServiceImpl implements AdminService {
 		// TODO Auto-generated method stub
 		return adminRepositorySupport.getTeamManagementData(projectId, regionCode);
 	}
+	
+	// Select Dash Board Info
+	@Override
+	public List<DashBoardTableResDto> getDashBoardTableInfo(Long projectId) {
+		return adminRepositorySupport.getDashBoardTableInfo(projectId);
+	}
+
+	// Select User Status to manage
+	@Override
+	public List<AdminUserManagementResDto> getUserManagamentData(Long projectId, int regionCode) {
+		return adminRepositorySupport.getUserManagamentData(projectId, regionCode);
+	}
+
 	/*
 	 * Select Code
 	 */
@@ -370,9 +384,17 @@ public class AdminServiceImpl implements AdminService {
 		return adminRepositorySupport.checkProjectDeletion(projectCode);
 	}
 
+	// Check Project Validation
 	@Override
-	public List<DashBoardTableResDto> getDashBoardTableInfo(Long projectId) {
-		return adminRepositorySupport.getDashBoardTableInfo(projectId);
+	public boolean checkProjectValidation(Long projectId) {
+		return adminRepositorySupport.checkProjectValidation(projectId);
+	}
+
+	// Class Select Box
+	@Override
+	public List<CodeResDto> getClassCode(Long projectId, int regionCode) {
+		
+		return adminRepositorySupport.getClassCode(projectId, regionCode);
 	}
 
 }


### PR DESCRIPTION
* 관리자가 교육생 관리 탭을 들어가게 되면 `전국` / `구미` / `광주` / `대전` / `서울` 별 교육생들의 정보를 확인할 수 있습니다.
  * region code가 0이면 전국, 그 외에는 공통 테이블에 정의되어 있는 코드별로 필터링 됩니다.

* 관리자가 교육생들의 반을 수정할 때 현재 프로젝트에 생성되어 있는 반의 리스트를 가져옵니다. 지역 별 필터링이 되었을 때 메뉴도 필터링 될 수 있게 하였습니다.
