### PR TITLE
feat : 비밀번호 초기화 기능 추가

### DIFF
--- a/BE/teamgu/build.gradle
+++ b/BE/teamgu/build.gradle
@@ -126,7 +126,6 @@ dependencies {
 	//민감정보 암호화
 	implementation("com.github.ulisesbocchio:jasypt-spring-boot-starter:1.17")
 
-
     implementation("com.auth0:java-jwt:3.10.3")
     implementation group: 'io.jsonwebtoken', name: 'jjwt', version: '0.2'
         
@@ -157,6 +156,9 @@ dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-validation' //for notnull
     testImplementation('org.springframework.boot:spring-boot-starter-test')
+
+    //이메일 발송 의존성 추가
+    implementation("org.springframework.boot:spring-boot-starter-mail")
 }
 
 //  test {

--- a/BE/teamgu/src/main/java/com/teamgu/api/controller/JwtAuthController.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/controller/JwtAuthController.java
@@ -84,8 +84,13 @@ public class JwtAuthController {
 
         Optional<User> opuser = userService.getUserByEmail(email);
         if (opuser.isPresent()) {
+
             User user = opuser.get();
-            if (passwordEncoder.matches(password, user.getPassword())) {
+
+            if (passwordEncoder.matches(password, user.getPassword())) { //기존 비밀번호로 로그인한 경우
+                return ResponseEntity.ok(userService.login(loginReq, user));
+            } else if(passwordEncoder.matches(password, user.getTempPassword())) { //발급받은 임시 비밀번호로 로그인한 경우
+                userService.modifyOriginPwd(user, user.getTempPassword());
                 return ResponseEntity.ok(userService.login(loginReq, user));
             }
         }

--- a/BE/teamgu/src/main/java/com/teamgu/api/controller/UserController.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/controller/UserController.java
@@ -2,11 +2,13 @@ package com.teamgu.api.controller;
 
 import java.util.List;
 
+import com.teamgu.api.dto.req.PasswordInitReqDto;
 import com.teamgu.api.dto.res.*;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 import com.teamgu.api.dto.req.PasswordReqDto;
@@ -20,24 +22,46 @@ import io.swagger.annotations.ApiParam;
 @Api(value = "마이페이지 정보 입력", tags = {"User."})
 @RestController
 @CrossOrigin("*")
-@RequestMapping("/api/auth")
+@RequestMapping("/api/user")
 @Log4j2
 public class UserController {
 
     @Autowired
     UserServiceImpl userService;
 
-    @PutMapping("/password")
+    @Transactional
+    @PatchMapping("/password/change")
     @ApiOperation(value = "비밀번호 변경", notes = "비밀번호를 변경한다.")
-    public ResponseEntity<? extends BasicResponse> setPassword(
+    public ResponseEntity<? extends BasicResponse> changePassword(
             @RequestBody @ApiParam(value = "비밀번호", required = true) PasswordReqDto password) {
 
-        if(!userService.setPassward(password)) {
+        if(!userService.changePassword(password)) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                     .body(new ErrorResponse("현재 비밀번호가 일치하지 않거나 이메일이 일치하는 유저가 없습니다."));
         }
 
         return ResponseEntity.ok(new CommonResponse<String>("비밀번호 변경 완료"));
+    }
+
+    @Transactional
+    @PatchMapping("/password/init")
+    @ApiOperation(value = "비밀번호 초기화", notes = "비밀번호를 초기화 한다.")
+    public ResponseEntity<? extends BasicResponse> initPassword(
+            @RequestBody @ApiParam(value = "초기화할 대상의 이메일", required = true) PasswordInitReqDto passwordInitReqDto) {
+
+        log.info(passwordInitReqDto.getEmail());
+
+        short result = userService.initPassword(passwordInitReqDto.getEmail());
+
+        if(result == 0) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(new ErrorResponse("일치하는 유저가 없습니다."));
+        } else if(result == -1) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new ErrorResponse("임시 비밀번호 발급에 실패하였습니다."));
+        }
+
+        return ResponseEntity.ok(new CommonResponse<String>("비밀번호 초기화 완료"));
     }
 
     @ApiOperation(value = "사용자 상세정보 조회", notes = "마이페이지에서 사용자 상세정보를 조회한다.")

--- a/BE/teamgu/src/main/java/com/teamgu/api/dto/MailDto.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/dto/MailDto.java
@@ -1,0 +1,24 @@
+package com.teamgu.api.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+/**
+ * 메일 전송에 사용될 dto
+ */
+@Data
+@Builder
+public class MailDto {
+
+    //받는 사람의 메일주소
+    private String address;
+
+    //메일의 제목
+    private String title;
+
+    //메일의 내용
+    private String message;
+
+    //첨부할 첨부파일
+    //private MultipartFile multipartFile;
+}

--- a/BE/teamgu/src/main/java/com/teamgu/api/dto/req/PasswordInitReqDto.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/dto/req/PasswordInitReqDto.java
@@ -1,0 +1,13 @@
+package com.teamgu.api.dto.req;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Data;
+
+@Data
+@ApiModel(description = "비밀번호 변경 요청 Dto")
+public class PasswordInitReqDto {
+
+    @ApiModelProperty(name = "email")
+    String email;
+}

--- a/BE/teamgu/src/main/java/com/teamgu/api/service/MailService.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/service/MailService.java
@@ -1,0 +1,7 @@
+package com.teamgu.api.service;
+
+import com.teamgu.api.dto.MailDto;
+
+public interface MailService {
+    void sendMail(MailDto mailDto);
+}

--- a/BE/teamgu/src/main/java/com/teamgu/api/service/MailServiceImpl.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/service/MailServiceImpl.java
@@ -1,0 +1,28 @@
+package com.teamgu.api.service;
+
+import com.teamgu.api.dto.MailDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MailServiceImpl implements MailService {
+
+    @Autowired
+    JavaMailSender javaMailSender;
+
+    private static final String from = "ssafy.teamgu@gmail.com";
+
+    @Override
+    public void sendMail(MailDto mailDto) {
+        SimpleMailMessage message = new SimpleMailMessage();
+
+        message.setFrom(from);
+        message.setTo(mailDto.getAddress());
+        message.setSubject(mailDto.getTitle());
+        message.setText(mailDto.getMessage());
+
+        javaMailSender.send(message);
+    }
+}

--- a/BE/teamgu/src/main/java/com/teamgu/api/service/UserService.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/service/UserService.java
@@ -29,7 +29,14 @@ public interface UserService {
 
     TokenResDto reissue(TokenReqDto tokenReq);
 
-    boolean setPassward(PasswordReqDto passwordReq);
+    //비밀번호 변경
+    boolean changePassword(PasswordReqDto passwordReq);
+
+    //임시 비밀번호 발급
+    short initPassword(String email);
+
+    //임시 비밀번호로 로그인시 원본 비번은 폐기, 임시 -> 원본 비밀번호로 변경
+    void modifyOriginPwd(User user, String tempPwd);
 
     // Email을 이용한 User Entity 조회
     Optional<User> getUserByEmail(String email);

--- a/BE/teamgu/src/main/java/com/teamgu/common/util/RandomPwdUtil.java
+++ b/BE/teamgu/src/main/java/com/teamgu/common/util/RandomPwdUtil.java
@@ -1,0 +1,50 @@
+package com.teamgu.common.util;
+
+import org.springframework.stereotype.Component;
+
+import java.security.SecureRandom;
+import java.util.Date;
+
+/**
+ * 10자리의 임시 비밀번호를 생성하는 클래스
+ *
+ * Random 함수 말고 SecureRandom을 사용하는 이유는
+ * 동일한 시간에 Random함수를 수행하게 되면 동일한 값을 리턴
+ *
+ * SecureRandom 내에 seed함수를 통해 강력한 난수 발생
+ */
+@Component
+public class RandomPwdUtil {
+
+    private final int size = 10;
+
+    public String getRandomPwd() {
+
+        char[] charSet = new char[]{
+                '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+                'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J',
+                'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T',
+                'U', 'V', 'W', 'X', 'Y', 'Z',
+                'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j',
+                'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't',
+                'u', 'v', 'w', 'x', 'y', 'z',
+                '!', '@', '#', '$', '%', '^', '&'
+        };
+
+//        StringBuffer sb = new StringBuffer(); //Thread-safe를 위해서는 StringBuffer 사용 필요
+        StringBuilder sb = new StringBuilder();
+        SecureRandom sr = new SecureRandom();
+
+        sr.setSeed(new Date().getTime());
+
+        int idx = 0;
+        int len = charSet.length;
+
+        for(int i = 0; i < this.size; i++) {
+            idx = sr.nextInt(len);
+            sb.append(charSet[idx]);
+        }
+
+        return sb.toString();
+    }
+}

--- a/BE/teamgu/src/main/java/com/teamgu/config/SecurityConfig.java
+++ b/BE/teamgu/src/main/java/com/teamgu/config/SecurityConfig.java
@@ -85,7 +85,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                         "/receive/chat/**",
                         "/stomp/**",
                         "/api/file/**",
-                        "/api/excel/**"
+                        "/api/excel/**",
+                        "/api/user/password/init"
                        )
                 .permitAll()
                 // 다른 모든 요청은 인증을 한다.

--- a/BE/teamgu/src/main/java/com/teamgu/database/entity/User.java
+++ b/BE/teamgu/src/main/java/com/teamgu/database/entity/User.java
@@ -32,6 +32,10 @@ public class User extends BaseEntity{
 	@JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
 	String password;
 
+	@JsonIgnore
+	@JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+	String tempPassword;
+
 	String refreshToken;
 	@Column(length = 7)
 	String studentNumber;

--- a/BE/teamgu/src/main/java/com/teamgu/database/repository/UserRepositorySupport.java
+++ b/BE/teamgu/src/main/java/com/teamgu/database/repository/UserRepositorySupport.java
@@ -3,6 +3,7 @@ package com.teamgu.database.repository;
 import java.util.List;
 
 import com.teamgu.api.dto.UserProfileImgDto;
+import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,75 +30,83 @@ import com.teamgu.database.entity.QWishTrack;
 import com.teamgu.database.entity.QUserProjectDetail;
 import com.teamgu.database.entity.QProjectDetail;
 
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.PersistenceUnit;
+
+@Log4j2
 @Repository
 public class UserRepositorySupport {
 
-	@Autowired
-	private JPAQueryFactory jpaQueryFactory;
+    @Autowired
+    private JPAQueryFactory jpaQueryFactory;
 
-	@Autowired
-	private CodeDetailRepositorySupport codeDetailRepositorySupport;
+    @Autowired
+    private CodeDetailRepositorySupport codeDetailRepositorySupport;
 
-	QUser qUser = QUser.user;
-	QSkill qSkill = QSkill.skill;
-	QWishTrack qWishTrack = QWishTrack.wishTrack;
-	QMapping qMapping = QMapping.mapping;
-	QCodeDetail qCodeDetail = QCodeDetail.codeDetail1;
-	QCode qCode = QCode.code1;
-	QUserClass qUserClass = QUserClass.userClass;
-	QStdClass qStdClass = QStdClass.stdClass;
-	QUserInfoAward qUserInfoAward = QUserInfoAward.userInfoAward;
-	QUserInfoProject qUserInfoProject = QUserInfoProject.userInfoProject;
-  QUserProjectDetail qUserProjectDetail = QUserProjectDetail.userProjectDetail;
-  QProjectDetail qProjectDetail = QProjectDetail.projectDetail;
-  
-	// User Detail Info 수정
-	@Transactional
-	public Long updateUserDetailInfo(UserInfoReqDto userInfoReqDto, UserProfileImgDto userProfileImgDto) {
+    @PersistenceUnit
+    EntityManagerFactory emf;
 
-		int positionCode = codeDetailRepositorySupport.findPositionCode(userInfoReqDto.getWishPosition());
+    QUser qUser = QUser.user;
+    QSkill qSkill = QSkill.skill;
+    QWishTrack qWishTrack = QWishTrack.wishTrack;
+    QMapping qMapping = QMapping.mapping;
+    QCodeDetail qCodeDetail = QCodeDetail.codeDetail1;
+    QCode qCode = QCode.code1;
+    QUserClass qUserClass = QUserClass.userClass;
+    QStdClass qStdClass = QStdClass.stdClass;
+    QUserInfoAward qUserInfoAward = QUserInfoAward.userInfoAward;
+    QUserInfoProject qUserInfoProject = QUserInfoProject.userInfoProject;
+    QUserProjectDetail qUserProjectDetail = QUserProjectDetail.userProjectDetail;
+    QProjectDetail qProjectDetail = QProjectDetail.projectDetail;
 
-		return jpaQueryFactory.update(qUser).where(qUser.id.eq(userInfoReqDto.getId()))
-				.set(qUser.introduce, userInfoReqDto.getIntroduce())
-				.set(qUser.wishPositionCode, positionCode)
-				.set(qUser.introduce, userInfoReqDto.getIntroduce())
-				.set(qUser.wishPositionCode, positionCode)
-				.set(qUser.profileOriginName, userProfileImgDto.getOriginName())
-				.set(qUser.profileServerName, userProfileImgDto.getServerName())
-				.set(qUser.profileExtension, userProfileImgDto.getExtension())
-				.execute();
+    // User Detail Info 수정
+    @Transactional
+    public Long updateUserDetailInfo(UserInfoReqDto userInfoReqDto, UserProfileImgDto userProfileImgDto) {
 
-	}
+        int positionCode = codeDetailRepositorySupport.findPositionCode(userInfoReqDto.getWishPosition());
 
-	// User 기술 스택 조회
-	public List<SkillResDto> selectUserSkillByUserId(Long userId) {
-		return jpaQueryFactory
-				.select(Projections.constructor(SkillResDto.class, qCodeDetail.codeDetail, qCodeDetail.Name))
-				.from(qSkill)
-				.join(qCodeDetail)
-				.on(qCodeDetail.codeDetail.eq(qSkill.skillCode))
-				.where(qSkill.user.id.eq(userId)
-						.and(qCodeDetail.code.code.eq("SK")))
-				.fetch();
-	}
-	
-	// User 기술 스택 삭제
-	@Transactional
-	public Long deleteUserSkill(Long userId, int skillCode ) {
-		return jpaQueryFactory
-				.delete(qSkill)
-				.where(qSkill.user.id.eq(userId)
-						.and(qSkill.skillCode.eq(skillCode)))
-				.execute();
-	}
-	
-	// User 수상 경력 조회
-	public List<UserInfoAwardResDto> selectUserAwardByUserId(Long userId) {
-		return jpaQueryFactory
-				.select(Projections.constructor(UserInfoAwardResDto.class, qUserInfoAward.id, qUserInfoAward.name,
-						qUserInfoAward.agency, qUserInfoAward.date, qUserInfoAward.introduce, qUserInfoAward.user.id))
-				.from(qUserInfoAward).where(qUserInfoAward.user.id.eq(userId)).fetch();
-	}
+        return jpaQueryFactory.update(qUser).where(qUser.id.eq(userInfoReqDto.getId()))
+                .set(qUser.introduce, userInfoReqDto.getIntroduce())
+                .set(qUser.wishPositionCode, positionCode)
+                .set(qUser.introduce, userInfoReqDto.getIntroduce())
+                .set(qUser.wishPositionCode, positionCode)
+                .set(qUser.profileOriginName, userProfileImgDto.getOriginName())
+                .set(qUser.profileServerName, userProfileImgDto.getServerName())
+                .set(qUser.profileExtension, userProfileImgDto.getExtension())
+                .execute();
+
+    }
+
+    // User 기술 스택 조회
+    public List<SkillResDto> selectUserSkillByUserId(Long userId) {
+        return jpaQueryFactory
+                .select(Projections.constructor(SkillResDto.class, qCodeDetail.codeDetail, qCodeDetail.Name))
+                .from(qSkill)
+                .join(qCodeDetail)
+                .on(qCodeDetail.codeDetail.eq(qSkill.skillCode))
+                .where(qSkill.user.id.eq(userId)
+                        .and(qCodeDetail.code.code.eq("SK")))
+                .fetch();
+    }
+
+    // User 기술 스택 삭제
+    @Transactional
+    public Long deleteUserSkill(Long userId, int skillCode) {
+        return jpaQueryFactory
+                .delete(qSkill)
+                .where(qSkill.user.id.eq(userId)
+                        .and(qSkill.skillCode.eq(skillCode)))
+                .execute();
+    }
+
+    // User 수상 경력 조회
+    public List<UserInfoAwardResDto> selectUserAwardByUserId(Long userId) {
+        return jpaQueryFactory
+                .select(Projections.constructor(UserInfoAwardResDto.class, qUserInfoAward.id, qUserInfoAward.name,
+                        qUserInfoAward.agency, qUserInfoAward.date, qUserInfoAward.introduce, qUserInfoAward.user.id))
+                .from(qUserInfoAward).where(qUserInfoAward.user.id.eq(userId)).fetch();
+    }
 
 //	// User Award 입력
 //	public Long insertUserInfoAward(UserInfoAwardResDto userInfoAwardResDto) {
@@ -105,31 +114,31 @@ public class UserRepositorySupport {
 //		return null;
 //	}
 
-	// User Award 수정
-	@Transactional
-	public Long updateUserInfoAward(UserInfoAwardResDto userInfoAwardResDto) {
+    // User Award 수정
+    @Transactional
+    public Long updateUserInfoAward(UserInfoAwardResDto userInfoAwardResDto) {
 
-		return jpaQueryFactory.update(qUserInfoAward).where(qUserInfoAward.id.eq(userInfoAwardResDto.getId()))
-				.set(qUserInfoAward.name, userInfoAwardResDto.getName())
-				.set(qUserInfoAward.agency, userInfoAwardResDto.getAgency())
-				.set(qUserInfoAward.date, userInfoAwardResDto.getDate())
-				.set(qUserInfoAward.introduce, userInfoAwardResDto.getIntroduce()).execute();
-	}
+        return jpaQueryFactory.update(qUserInfoAward).where(qUserInfoAward.id.eq(userInfoAwardResDto.getId()))
+                .set(qUserInfoAward.name, userInfoAwardResDto.getName())
+                .set(qUserInfoAward.agency, userInfoAwardResDto.getAgency())
+                .set(qUserInfoAward.date, userInfoAwardResDto.getDate())
+                .set(qUserInfoAward.introduce, userInfoAwardResDto.getIntroduce()).execute();
+    }
 
-	// User Award 삭제
-	@Transactional
-	public Long deleteUserInfoAward(Long id) {
-		return jpaQueryFactory.delete(qUserInfoAward).where(qUserInfoAward.id.eq(id)).execute();
-	}
+    // User Award 삭제
+    @Transactional
+    public Long deleteUserInfoAward(Long id) {
+        return jpaQueryFactory.delete(qUserInfoAward).where(qUserInfoAward.id.eq(id)).execute();
+    }
 
-	// User Project 조회
-	public List<UserInfoProjectResDto> selectUserProjectByUserId(Long userId) {
-		return jpaQueryFactory
-				.select(Projections.constructor(UserInfoProjectResDto.class, qUserInfoProject.id, qUserInfoProject.name,
-						qCodeDetail.Name, qUserInfoProject.url, qUserInfoProject.introduce, qUserInfoProject.user.id))
-				.from(qUserInfoProject).join(qCodeDetail).on(qUserInfoProject.positionCode.eq(qCodeDetail.codeDetail))
-				.where(qUserInfoProject.user.id.eq(userId).and(qCodeDetail.code.code.eq("PO"))).fetch();
-	}
+    // User Project 조회
+    public List<UserInfoProjectResDto> selectUserProjectByUserId(Long userId) {
+        return jpaQueryFactory
+                .select(Projections.constructor(UserInfoProjectResDto.class, qUserInfoProject.id, qUserInfoProject.name,
+                        qCodeDetail.Name, qUserInfoProject.url, qUserInfoProject.introduce, qUserInfoProject.user.id))
+                .from(qUserInfoProject).join(qCodeDetail).on(qUserInfoProject.positionCode.eq(qCodeDetail.codeDetail))
+                .where(qUserInfoProject.user.id.eq(userId).and(qCodeDetail.code.code.eq("PO"))).fetch();
+    }
 
 //	//User Project 입력
 //	public Long insertUserInfoProject(UserInfoProjectResDto userInfoProjectResDto, User user) {
@@ -155,62 +164,86 @@ public class UserRepositorySupport {
 //		return 1L;
 //	}
 
-	// User Project 수정
-	@Transactional
-	public Long updateUserInfoProject(UserInfoProjectResDto userInfoProjectResDto, int positionCode) {
-		return jpaQueryFactory.update(qUserInfoProject).where(qUserInfoProject.id.eq(userInfoProjectResDto.getId()))
-				.set(qUserInfoProject.name, userInfoProjectResDto.getName())
-				.set(qUserInfoProject.introduce, userInfoProjectResDto.getIntroduce())
-				.set(qUserInfoProject.url, userInfoProjectResDto.getUrl())
-				.set(qUserInfoProject.positionCode, positionCode).execute();
-	}
+    // User Project 수정
+    @Transactional
+    public Long updateUserInfoProject(UserInfoProjectResDto userInfoProjectResDto, int positionCode) {
+        return jpaQueryFactory.update(qUserInfoProject).where(qUserInfoProject.id.eq(userInfoProjectResDto.getId()))
+                .set(qUserInfoProject.name, userInfoProjectResDto.getName())
+                .set(qUserInfoProject.introduce, userInfoProjectResDto.getIntroduce())
+                .set(qUserInfoProject.url, userInfoProjectResDto.getUrl())
+                .set(qUserInfoProject.positionCode, positionCode).execute();
+    }
 
-	// User Project 삭제
-	@Transactional
-	public void deleteUserInfoProject(Long id) {
+    // User Project 삭제
+    @Transactional
+    public void deleteUserInfoProject(Long id) {
 
-		jpaQueryFactory.delete(qUserInfoProject).where(qUserInfoProject.id.eq(id)).execute();
-	}
+        jpaQueryFactory.delete(qUserInfoProject).where(qUserInfoProject.id.eq(id)).execute();
+    }
 
-	// User Wish Track 조회
-	public List<TrackReqDto> selectUserWishTrackByUserId(Long userId) {
-		return jpaQueryFactory.select(Projections.constructor(TrackReqDto.class, qCodeDetail.codeDetail, qCodeDetail.Name)).from(qWishTrack).leftJoin(qWishTrack.mapping, qMapping)
-				.join(qCodeDetail).on(qMapping.trackCode.eq(qCodeDetail.codeDetail))
-				.where(qWishTrack.user.id.eq(userId).and(qCodeDetail.code.code.eq("TR"))).fetch();
-	}
-	
-	// User Wish Track 삭제
-	@Transactional
-	public void deleteUserWishTrack(Long userId, Long mappingId) {
+    // User Wish Track 조회
+    public List<TrackReqDto> selectUserWishTrackByUserId(Long userId) {
+        return jpaQueryFactory.select(Projections.constructor(TrackReqDto.class, qCodeDetail.codeDetail, qCodeDetail.Name)).from(qWishTrack).leftJoin(qWishTrack.mapping, qMapping)
+                .join(qCodeDetail).on(qMapping.trackCode.eq(qCodeDetail.codeDetail))
+                .where(qWishTrack.user.id.eq(userId).and(qCodeDetail.code.code.eq("TR"))).fetch();
+    }
 
-		jpaQueryFactory
-				.delete(qWishTrack)
-				.where(qWishTrack.user.id.eq(userId)
-						.and(qWishTrack.mapping.id.eq(mappingId)))
-				.execute();
-	}
+    // User Wish Track 삭제
+    @Transactional
+    public void deleteUserWishTrack(Long userId, Long mappingId) {
 
-	// User Class 조회
-	public UserClassResDto selectUserClassByUserId(Long userId, int stage) {
-		UserClassResDto userClassDto = (UserClassResDto) jpaQueryFactory
-				.select(Projections.constructor(UserClassResDto.class, qStdClass.name, qCodeDetail.Name))
-				.from(qUserClass).leftJoin(qUserClass.stdClass, qStdClass).join(qCodeDetail)
-				.on(qStdClass.regionCode.eq(qCodeDetail.codeDetail)).where(qUserClass.user.id.eq(userId)
-						.and(qStdClass.stageCode.eq(stage + 100)).and(qCodeDetail.code.code.eq("RE")))
-				.fetchOne();
-		return userClassDto;
+        jpaQueryFactory
+                .delete(qWishTrack)
+                .where(qWishTrack.user.id.eq(userId)
+                        .and(qWishTrack.mapping.id.eq(mappingId)))
+                .execute();
+    }
 
-	}
+    // User Class 조회
+    public UserClassResDto selectUserClassByUserId(Long userId, int stage) {
+        UserClassResDto userClassDto = (UserClassResDto) jpaQueryFactory
+                .select(Projections.constructor(UserClassResDto.class, qStdClass.name, qCodeDetail.Name))
+                .from(qUserClass).leftJoin(qUserClass.stdClass, qStdClass).join(qCodeDetail)
+                .on(qStdClass.regionCode.eq(qCodeDetail.codeDetail)).where(qUserClass.user.id.eq(userId)
+                        .and(qStdClass.stageCode.eq(stage + 100)).and(qCodeDetail.code.code.eq("RE")))
+                .fetchOne();
+        return userClassDto;
 
-  // User의 ProjectCode List조회
-  public List<Integer> selectUserProjectCodes(Long userId) {
-      return jpaQueryFactory
-              .select(Projections.constructor(Integer.class,
-                      qProjectDetail.projectCode))
-              .from(qUserProjectDetail)
-              .innerJoin(qUserProjectDetail.projectDetail, qProjectDetail)
-              .where(qUserProjectDetail.user.id.eq(userId))
-              .fetch();
-  }
-  
+    }
+
+    // User의 ProjectCode List조회
+    public List<Integer> selectUserProjectCodes(Long userId) {
+        return jpaQueryFactory
+                .select(Projections.constructor(Integer.class,
+                        qProjectDetail.projectCode))
+                .from(qUserProjectDetail)
+                .innerJoin(qUserProjectDetail.projectDetail, qProjectDetail)
+                .where(qUserProjectDetail.user.id.eq(userId))
+                .fetch();
+    }
+
+    //임시 비밀번호를 원본으로 변경
+    //원본 비밀번호는 폐기
+    @Transactional
+    public void updateTempPasswordToOrigin(Long id, String email, String tmpPwd) {
+        StringBuilder jpql = new StringBuilder();
+        EntityManager em = emf.createEntityManager();
+
+        jpql.append("update user set password= '" + tmpPwd +"', temp_password=''");
+        jpql.append(" where id=" + id + " and email = '" + email + "'");
+
+        em.createNativeQuery(jpql.toString());
+
+        em.close();
+//        log.info(id + " " + email + " " + tmpPwd);
+//
+//        jpaQueryFactory.update(qUser)
+//                .set(qUser.tempPassword, "")
+//                .set(qUser.password, tmpPwd)
+//                .where(qUser.id.eq(id).and(qUser.email.eq(email)))
+//                .execute();
+//
+//        jpaQueryFactory.selectFrom(qUser).fetch();
+    }
+
 }


### PR DESCRIPTION
- 사용자는 이메일을 통해 임시 비밀번호를 발급 받을 수 있다
- 임시 비밀번호는 사용자의 email로 발송된다
- 발송된 임시 비밀번호로 로그인 함과 동시에 원본 비밀번호는 임시 비밀번호로 대체된다
	- 악의적으로 원본 비밀번호 사용 못하게 하려는 경우 막기 위함