### PR TITLE
feat: Student Class 추가 및 삭제, Admin Team Management Error 수정

### DIFF
--- a/BE/teamgu/src/main/java/com/teamgu/api/dto/req/StdClassReqDto.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/dto/req/StdClassReqDto.java
@@ -1,0 +1,16 @@
+package com.teamgu.api.dto.req;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+
+@Getter
+@ApiModel(description = "교육생 프로젝트 반 추가 요청 모델")
+public class StdClassReqDto {
+
+	@ApiModelProperty(name = "project id")
+	Long projectId;
+	
+	@ApiModelProperty(name = "project student class name")
+	String className;
+}

--- a/BE/teamgu/src/main/java/com/teamgu/api/service/AdminService.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/service/AdminService.java
@@ -161,5 +161,50 @@ public interface AdminService {
 	 * @param regionCode
 	 * @return
 	 */
-	public List<CodeResDto> getClassCode(Long projectId, int regionCode);
+	public List<CodeResDto> selectStudentClass(Long projectId, int regionCode);
+	
+	/**
+	 * Check Student Class Deletion
+	 * 추가한 교육생 반을 삭제할 수 있는지 체크한다.
+	 * user_class에 해당하는 반의 데이터가 존재하면 삭제하지 못하도록 처리한다.
+	 * @param classId
+	 * @return
+	 */
+	public boolean checkStudentClassDeletion(Long classId) ;
+	
+	/**
+	 * Delete Student Class
+	 * 교육생 반을 삭제한다.
+	 * @param classId
+	 */
+	public void deleteStudentClass(Long classId);
+
+	/**
+	 * Check Region Code
+	 * 반을 추가할 때 등록되어 있는 지역인지 먼저 체크한다.
+	 * 등록되어 있는 지역이면 지역 코드를 반환한다.
+	 * @param region
+	 * @return
+	 */
+	public int checkRegionCode(String region);
+	
+	/**
+	 * Check Student Class Duplication
+	 * 반을 추가할 때 이미 존재하는 반인지 체크한다
+	 * 존재하지 않으면 true, 존재하면 false를 반환한다
+	 * @param projectId
+	 * @param regionCode
+	 * @param name
+	 * @return
+	 */
+	public boolean checkStudentClassDuplication(Long projectId, int regionCode, int name);
+
+	/**
+	 * Insert Student Class
+	 * 반을 추가한다.
+	 * @param projectId
+	 * @param regionCode
+	 * @param name
+	 */
+	public void insertStudentClass(Long projectId, int regionCode, int name);
 }

--- a/BE/teamgu/src/main/java/com/teamgu/api/service/AdminServiceImpl.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/service/AdminServiceImpl.java
@@ -392,9 +392,37 @@ public class AdminServiceImpl implements AdminService {
 
 	// Class Select Box
 	@Override
-	public List<CodeResDto> getClassCode(Long projectId, int regionCode) {
+	public List<CodeResDto> selectStudentClass(Long projectId, int regionCode) {
 		
-		return adminRepositorySupport.getClassCode(projectId, regionCode);
+		return adminRepositorySupport.selectStudentClass(projectId, regionCode);
+	}
+	// Check Student Class Deletion
+	@Override
+	public boolean checkStudentClassDeletion(Long classId) {
+		return adminRepositorySupport.checkStudentClassDeletion(classId);
+	}
+
+	//Delete Student Class
+	@Override
+	public void deleteStudentClass(Long classId) {
+		adminRepositorySupport.deleteStudentClass(classId);
+	}
+	
+	// Check Region Code
+	@Override
+	public int checkRegionCode(String region) {
+		return adminRepositorySupport.checkRegionCode(region);
+	}
+
+	// Project별 Student Class Duplication Check
+	@Override
+	public boolean checkStudentClassDuplication(Long projectId, int regionCode, int name) {
+		return adminRepositorySupport.checkStudentClassDuplication(projectId, regionCode, name);
+	}
+
+	@Override
+	public void insertStudentClass(Long projectId, int regionCode, int name) {
+		adminRepositorySupport.insertStudentClass(projectId, regionCode, name);
 	}
 
 }

--- a/BE/teamgu/src/main/java/com/teamgu/database/repository/AdminRepositorySupport.java
+++ b/BE/teamgu/src/main/java/com/teamgu/database/repository/AdminRepositorySupport.java
@@ -73,26 +73,33 @@ public class AdminRepositorySupport {
 				.where(qCodeDetail.code.code.eq(codeId))
 				.fetchOne().intValue();
 		
-
-		log.info("insertStageCode codeId : " + codeId);
-		log.info("insertStageCode lastCode : " + lastCode);
-		log.info("insertStageCode codeName : " + codeName);
-		
 		EntityManager em = emf.createEntityManager();
 		EntityTransaction et = em.getTransaction();
+		
+		try {
 
-		et.begin();
+			et.begin();
 
-		String jpql = "INSERT INTO code_detail values(?1, ?2, ?3)";
+			String jpql = "INSERT INTO code_detail values(?1, ?2, ?3)";
 
-		em.createNativeQuery(jpql)
-		.setParameter(1, codeId)
-		.setParameter(2, lastCode +1)
-		.setParameter(3, codeName)
-		.executeUpdate();
+			em.createNativeQuery(jpql)
+			.setParameter(1, codeId)
+			.setParameter(2, lastCode +1)
+			.setParameter(3, codeName)
+			.executeUpdate();
 
-		et.commit();
-		em.close();
+			et.commit();
+			
+		} catch (Exception e) {
+			
+			et.rollback();
+			e.printStackTrace();
+			
+		} finally {
+
+			em.close();
+			
+		}
 		
 	}
 	
@@ -113,21 +120,34 @@ public class AdminRepositorySupport {
 
 		EntityManager em = emf.createEntityManager();
 		EntityTransaction et = em.getTransaction();
+		
+		try {
+			
+			et.begin();
 
-		et.begin();
+			String jpql = "INSERT INTO project_detail(project_code, stage_code, active_date, start_date, end_date) "
+					+ "values(:projectCode, :stageCode, :activeDate, :startDate, :endDate)";
 
-		String jpql = "INSERT INTO project_detail(project_code, stage_code, active_date, start_date, end_date) values(?1, ?2, ?3, ?4, ?5)";
+			em.createNativeQuery(jpql)
+			.setParameter("projectCode", projectInfoResDto.getProject().getCode())
+			.setParameter("stageCode", projectInfoResDto.getStage().getCode())
+			.setParameter("activeDate", projectInfoResDto.getActiveDate())
+			.setParameter("startDate", projectInfoResDto.getStartDate())
+			.setParameter("endDate", projectInfoResDto.getEndDate())
+			.executeUpdate();
 
-		em.createNativeQuery(jpql)
-		.setParameter(1, projectInfoResDto.getProject().getCode())
-		.setParameter(2, projectInfoResDto.getStage().getCode())
-		.setParameter(3, projectInfoResDto.getActiveDate())
-		.setParameter(4, projectInfoResDto.getStartDate())
-		.setParameter(5, projectInfoResDto.getEndDate())
-		.executeUpdate();
+			et.commit();
+			
+		} catch (Exception e) {
+			
+			et.rollback();
+			e.printStackTrace();
 
-		et.commit();
-		em.close();
+		} finally {
+			
+			em.close();
+			
+		}
 		
 	}
 	
@@ -669,13 +689,15 @@ public class AdminRepositorySupport {
 			.setParameter("regionCode", regionCode)
 			.executeUpdate();
 
+			et.commit();
+			
 		} catch (Exception e) {
 			
+			et.rollback();
 			e.printStackTrace();
 		
 		} finally {
 
-			et.commit();
 			em.close();
 			
 		}


### PR DESCRIPTION
* `관리자` 팀 구성 현황 조회 시 하나의 프로젝트만 조회되는 문제 해결
* `Student Class` `추가`기능 구현
  * [지역] + [반] 형식이 맞는지 체크
  * 관리 지역이 맞는지 체크
  * 중복이 있는지 체크
* `Student Class` `삭제` 기능 구현
  * 해당 Student Class에 존재하는 교육생이 있는지 체크
* `Team` Filter Logic 일부 수정