### PR TITLE
비밀번호 초기화 모달을 만듭니다

### DIFF
--- a/FE/components/organisms/Main/Main.tsx
+++ b/FE/components/organisms/Main/Main.tsx
@@ -2,7 +2,8 @@ import { ReactElement, SyntheticEvent, useRef, useState } from 'react';
 import { useRouter } from 'next/router';
 import Image from 'next/image';
 import { Input, Text } from '@atoms';
-import { useAppDispatch, setLogin } from '@store';
+import { useAppDispatch, setLogin, displayModal } from '@store';
+import { MODALS } from '@utils/constants';
 import { Label, Button } from '@molecules';
 import styled from 'styled-components';
 
@@ -56,7 +57,7 @@ const Wrapper = styled.div<{ img: string }>`
   }
 
   .errorMessage {
-    margin-top: 35px;
+    margin-top: 20px;
     margin-left: 12px;
   }
 
@@ -80,6 +81,12 @@ const Wrapper = styled.div<{ img: string }>`
   }
 `;
 
+const FindPassword = styled.div`
+  margin-top: 8px;
+  ${({ theme: { flexRow } }) => flexRow()};
+  cursor: pointer;
+`;
+
 export default function Home(): ReactElement {
   const router = useRouter();
   const dispatch = useAppDispatch();
@@ -88,6 +95,14 @@ export default function Home(): ReactElement {
   const passwordRef: any = useRef<HTMLInputElement>(null);
   const [error, setError] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
+
+  const findPassword = async () => {
+    dispatch(
+      displayModal({
+        modalName: MODALS.FINDPASSWORD_MODAL,
+      }),
+    );
+  };
 
   const handleLogin = async (e: SyntheticEvent) => {
     e.preventDefault();
@@ -168,6 +183,9 @@ export default function Home(): ReactElement {
             <div className="form-btn">
               <Button title="로그인" type="submit" width={'90%'} />
             </div>
+            <FindPassword onClick={findPassword}>
+              <Text text="비밀번호 찾기" color="#a9aeb4" />
+            </FindPassword>
           </div>
         </div>
       </form>

--- a/FE/components/organisms/Main/Modal/FindPasswordModal.tsx
+++ b/FE/components/organisms/Main/Modal/FindPasswordModal.tsx
@@ -1,0 +1,89 @@
+import { ReactElement, SyntheticEvent, useState, useRef } from 'react';
+import styled from 'styled-components';
+import { Input } from '@atoms';
+import { Button } from '@molecules';
+import { findPassword } from '@repository/userprofile';
+import { useAppDispatch, removeModal } from '@store';
+import { MODALS } from '@utils/constants';
+
+const Wrapper = styled.div`
+  margin: 30px;
+`;
+
+const FindPW = styled.div`
+  div {
+    margin-bottom: 15px;
+
+    button {
+      width: 5vw;
+      height: 20px;
+      margin-left: 5px;
+    }
+  }
+`;
+
+const Error = styled.div`
+  font-weight: 900;
+  color: red;
+`;
+
+export default function FindPasswordModal(): ReactElement {
+  const dispatch = useAppDispatch();
+
+  const [error, setError] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const emailRef = useRef<HTMLInputElement>(null);
+
+  const handlePassword = async (e: SyntheticEvent) => {
+    e.preventDefault();
+    if (!emailRef?.current?.value) {
+      setErrorMessage('이메일을 입력해주세요.');
+      setError(true);
+      return;
+    }
+
+    try {
+      const data = {
+        email: emailRef?.current?.value,
+      };
+      console.log(data);
+      await findPassword(data);
+      alert('비밀번호가 초기화 되었습니다.');
+      dispatch(removeModal({ modalName: MODALS.FINDPASSWORD_MODAL }));
+    } catch (e) {
+      console.log(e);
+      setErrorMessage('올바르지 않은 이메일입니다.');
+      setError(true);
+    }
+  };
+
+  return (
+    <Wrapper>
+      <form onSubmit={handlePassword}>
+        <FindPW>
+          <div>
+            <Input
+              placeHolder={'이메일을 입력해주세요.'}
+              width="30vw"
+              height="50px"
+              ref={emailRef}
+              maxLength={30}
+              autoComplete="off"
+            />
+          </div>
+          {error && <Error>{errorMessage}</Error>}
+          <div>
+            <Button title="확인" type="submit" />
+            <Button
+              title="닫기"
+              func={() =>
+                dispatch(removeModal({ modalName: MODALS.FINDPASSWORD_MODAL }))
+              }
+            />
+          </div>
+        </FindPW>
+      </form>
+    </Wrapper>
+  );
+}

--- a/FE/components/organisms/Main/Modal/index.ts
+++ b/FE/components/organisms/Main/Modal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './FindPasswordModal';

--- a/FE/components/organisms/Modal/Modal.tsx
+++ b/FE/components/organisms/Modal/Modal.tsx
@@ -9,6 +9,7 @@ import {
   AwardModal,
   ChangePasswordModal,
 } from '../UserDetail/MyDetail/Modal';
+import FindPasswordModal from '../Main/Modal';
 
 interface ModalProps {
   modalName: string;
@@ -32,6 +33,7 @@ export default function Modal({
               [MODALS.AWARD_MODAL]: <AwardModal />,
               [MODALS.HOC_MODAL]: <HocModal>{children}</HocModal>,
               [MODALS.CHANGEPASSWORD_MODAL]: <ChangePasswordModal />,
+              [MODALS.FINDPASSWORD_MODAL]: <FindPasswordModal />,
             }[modalName]
           }
         </ModalWrapper>

--- a/FE/components/organisms/UserDetail/MyDetail/Modal/ChangePasswordModal.tsx
+++ b/FE/components/organisms/UserDetail/MyDetail/Modal/ChangePasswordModal.tsx
@@ -107,7 +107,7 @@ export default function ChangePasswordModal(): ReactElement {
               width="30vw"
               height="50px"
               ref={emailRef}
-              maxLength={20}
+              maxLength={30}
               autoComplete="off"
             />
           </div>

--- a/FE/pages/main/index.tsx
+++ b/FE/pages/main/index.tsx
@@ -1,9 +1,0 @@
-import { ReactElement, useEffect } from 'react';
-
-import { useAppDispatch, setUserInfo } from '@store';
-
-export default function User(): ReactElement {
-  const dispatch = useAppDispatch();
-
-  return <></>;
-}

--- a/FE/repository/userprofile.ts
+++ b/FE/repository/userprofile.ts
@@ -65,8 +65,16 @@ export const getUserDetailbyRefresh = async () => {
 
 export const changePassword = async (param: object) => {
   await api({
-    url: '/api/user/password',
+    url: '/api/user/password/change',
     type: 'put',
+    param,
+  });
+};
+
+export const findPassword = async (param: object) => {
+  await api({
+    url: '/api/user/password/init',
+    type: 'patch',
     param,
   });
 };

--- a/FE/store/modalSlice.ts
+++ b/FE/store/modalSlice.ts
@@ -8,6 +8,7 @@ interface ModalState {
   [MODALS.AWARD_MODAL]: boolean;
   [MODALS.HOC_MODAL]: boolean;
   [MODALS.CHANGEPASSWORD_MODAL]: boolean;
+  [MODALS.FINDPASSWORD_MODAL]: boolean;
   content?: any;
 }
 
@@ -17,6 +18,7 @@ const initialState: ModalState = {
   [MODALS.AWARD_MODAL]: false,
   [MODALS.HOC_MODAL]: false,
   [MODALS.CHANGEPASSWORD_MODAL]: false,
+  [MODALS.FINDPASSWORD_MODAL]: false,
   content: '',
 };
 

--- a/FE/utils/constants.ts
+++ b/FE/utils/constants.ts
@@ -4,12 +4,14 @@ export const MODALS: {
   AWARD_MODAL: string;
   HOC_MODAL: string;
   CHANGEPASSWORD_MODAL: string;
+  FINDPASSWORD_MODAL: string;
 } = {
   ALERT_MODAL: 'alertModal',
   PROJECT_MODAL: 'projectModal',
   AWARD_MODAL: 'awardModal',
   HOC_MODAL: 'hocModal',
   CHANGEPASSWORD_MODAL: 'changePasswordModal',
+  FINDPASSWORD_MODAL: 'findPasswordModal',
 };
 
 export const PROJECT_CODE: any = {
@@ -99,7 +101,6 @@ export const ADMIN_DASHBOARD_TABLE_COLUMNS = [
     accessor: 'position',
   },
 ];
-
 
 export const REGIONS = [
   {


### PR DESCRIPTION
> Resolve [#S05P13A202-318](https://jira.ssafy.com/browse/S05P13A202-318)

비밀번호 변경이 가능해졌기 때문에 초기화 또한 필요해졌습니다. 사용자의 아이디는 실제 사용자가 사용하는 이메일이라는 가정이 있기 때문에 해당 메일로 임시 비밀번호가 가게 됩니다.
다른 사용자가 악의적으로 다른 사용자의 이메일을 활용하여 다른 사용자의 비밀번호를 초기화버릴 수도 있습니다. 해당 부분은 백엔드에서 처리가 되었고, 바뀐 비밀번호로 첫 로그인을 수행할 시 해당 비밀번호로 바뀌게 되고 그전까지는 기존의 비밀번호와 바뀌게 될 비밀번호 이 두가지 모두로 로그인이 가능하게 처리하셨다고 들었습니다.