### PR TITLE
안읽은 메시지가 있을 경우 채팅방 접속시 읽은위치까지만 이동한다

### DIFF
--- a/FE/components/molecules/ChatBubble/ChatBubble.tsx
+++ b/FE/components/molecules/ChatBubble/ChatBubble.tsx
@@ -15,7 +15,7 @@ interface ChatBubbleProps {
   // TODO: 추후 타입 정의
   time: string | any;
   message: string;
-  handleGetChatRoomMessages: any;
+  handleGetChatRoomMessages?: any;
   isMe?: boolean;
   // TODO: 추후 타입 정의
   func?: any;

--- a/FE/components/molecules/ChatBubble/ChatBubble.tsx
+++ b/FE/components/molecules/ChatBubble/ChatBubble.tsx
@@ -1,4 +1,4 @@
-import { ReactElement } from 'react';
+import { ReactElement, forwardRef } from 'react';
 import styled from 'styled-components';
 import { useRouter } from 'next/router';
 
@@ -78,111 +78,118 @@ const Wrapper = styled.div<{ isMe: boolean }>`
   }
 `;
 
-export default function ChatBubble({
-  profileSrc,
-  userName = '',
-  time,
-  message,
-  handleGetChatRoomMessages,
-  isMe = false,
-  // func,
-  type = 'NORMAL',
-  roomId = 0,
-  opponentId = 0,
-  chatId = 0,
-  teamId = 0,
-  id = 0,
-}: ChatBubbleProps): ReactElement {
-  const router = useRouter();
+const ChatBubble = forwardRef<HTMLInputElement, ChatBubbleProps>(
+  (
+    {
+      profileSrc,
+      userName = '',
+      time,
+      message = '',
+      handleGetChatRoomMessages,
+      isMe = false,
+      // func,
+      type = 'NORMAL',
+      roomId = 0,
+      opponentId = 0,
+      chatId = 0,
+      teamId = 0,
+      id = 0,
+    }: ChatBubbleProps,
+    ref,
+  ): ReactElement => {
+    const router = useRouter();
 
-  return (
-    <Wrapper isMe={isMe}>
-      {!isMe && <ProfileImage src={profileSrc} />}
-      <div className="chat">
-        <div className="chat-info">
-          {!isMe && <Text text={userName} fontSetting="n14b" />}
-          <Text text={time} fontSetting="n10m" />
+    return (
+      <Wrapper isMe={isMe} ref={ref}>
+        {!isMe && <ProfileImage src={profileSrc} />}
+        <div className="chat">
+          <div className="chat-info">
+            {!isMe && <Text text={userName} fontSetting="n14b" />}
+            <Text text={time} fontSetting="n10m" />
+          </div>
+          <div className="chat-message">
+            {type !== null && type !== 'NORMAL' ? (
+              {
+                RTC_INVITE: (
+                  <ChatBubbleSelect
+                    text="화상전화 요청"
+                    funcAccept={() => router.push(`rtc/${roomId}`)}
+                  />
+                ),
+                TEAM_INVITE_WAITING: isMe ? (
+                  <Text
+                    text={'상대방이 팀원 초대를 기다리고 있습니다.'}
+                    fontSetting="n16m"
+                    isLineBreak
+                  />
+                ) : opponentId !== 0 && id !== 0 && chatId !== 0 ? (
+                  <ChatBubbleSelect
+                    text="팀원초대 요청"
+                    funcAccept={async () => {
+                      await postTeamInviteAccept({
+                        invitee_id: id,
+                        leader_id: opponentId,
+                        message_id: chatId,
+                        team_id: teamId,
+                      });
+                      handleGetChatRoomMessages();
+                    }}
+                    funcDecline={async () => {
+                      await postTeamInviteReject({
+                        invitee_id: id,
+                        leader_id: opponentId,
+                        message_id: chatId,
+                        team_id: teamId,
+                      });
+                      handleGetChatRoomMessages();
+                    }}
+                    isTeamInvite
+                  />
+                ) : (
+                  <ChatLoading />
+                ),
+                TEAM_INVITE_ACCEPTED: (
+                  <Text
+                    text={
+                      isMe
+                        ? '상대방이 팀원 초대를 수락했습니다.'
+                        : '팀 초대를 수락했습니다'
+                    }
+                    fontSetting="n16m"
+                    isLineBreak
+                  />
+                ),
+                TEAM_INVITE_REJECTED: (
+                  <Text
+                    text={
+                      isMe
+                        ? '상대방이 팀원 초대를 거절했습니다'
+                        : '팀 초대를 거절했습니다'
+                    }
+                    fontSetting="n16m"
+                    isLineBreak
+                  />
+                ),
+                TEAM_INVITE_EXPIRED: (
+                  <Text
+                    text={
+                      isMe
+                        ? '시간이 만료되었습니다. 다시 초대해주세요.'
+                        : '시간이 만료되었습니다.'
+                    }
+                    fontSetting="n16m"
+                    isLineBreak
+                  />
+                ),
+              }[type]
+            ) : (
+              <Text text={message} fontSetting="n12m" isLineBreak />
+            )}
+          </div>
         </div>
-        <div className="chat-message">
-          {type !== null && type !== 'NORMAL' ? (
-            {
-              RTC_INVITE: (
-                <ChatBubbleSelect
-                  text="화상전화 요청"
-                  funcAccept={() => router.push(`rtc/${roomId}`)}
-                />
-              ),
-              TEAM_INVITE_WAITING: isMe ? (
-                <Text
-                  text={'상대방이 팀원 초대를 기다리고 있습니다.'}
-                  fontSetting="n16m"
-                  isLineBreak
-                />
-              ) : opponentId !== 0 && id !== 0 && chatId !== 0 ? (
-                <ChatBubbleSelect
-                  text="팀원초대 요청"
-                  funcAccept={async () => {
-                    await postTeamInviteAccept({
-                      invitee_id: id,
-                      leader_id: opponentId,
-                      message_id: chatId,
-                      team_id: teamId,
-                    });
-                    handleGetChatRoomMessages();
-                  }}
-                  funcDecline={async () => {
-                    await postTeamInviteReject({
-                      invitee_id: id,
-                      leader_id: opponentId,
-                      message_id: chatId,
-                      team_id: teamId,
-                    });
-                    handleGetChatRoomMessages();
-                  }}
-                  isTeamInvite
-                />
-              ) : (
-                <ChatLoading />
-              ),
-              TEAM_INVITE_ACCEPTED: (
-                <Text
-                  text={
-                    isMe
-                      ? '상대방이 팀원 초대를 수락했습니다.'
-                      : '팀 초대를 수락했습니다'
-                  }
-                  fontSetting="n16m"
-                  isLineBreak
-                />
-              ),
-              TEAM_INVITE_REJECTED: (
-                <Text
-                  text={
-                    isMe
-                      ? '상대방이 팀원 초대를 거절했습니다'
-                      : '팀 초대를 거절했습니다'
-                  }
-                  fontSetting="n16m"
-                  isLineBreak
-                />
-              ),
-              TEAM_INVITE_EXPIRED: (
-                <Text
-                  text={
-                    isMe
-                      ? '시간이 만료되었습니다. 다시 초대해주세요.'
-                      : '시간이 만료되었습니다.'
-                  }
-                  fontSetting="n16m"
-                  isLineBreak
-                />
-              ),
-            }[type]
-          ) : (
-            <Text text={message} fontSetting="n12m" isLineBreak />
-          )}
-        </div>
-      </div>
-    </Wrapper>
-  );
-}
+      </Wrapper>
+    );
+  },
+);
+
+export default ChatBubble;

--- a/FE/components/molecules/ChatBubble/ChatBubble.tsx
+++ b/FE/components/molecules/ChatBubble/ChatBubble.tsx
@@ -6,7 +6,7 @@ import {
   postTeamInviteAccept,
   postTeamInviteReject,
 } from '@repository/chatRepository';
-import { ProfileImage, ChatBubbleSelect } from '@molecules';
+import { ProfileImage, ChatBubbleSelect, ChatLoading } from '@molecules';
 import { Text } from '@atoms';
 
 interface ChatBubbleProps {
@@ -118,7 +118,7 @@ export default function ChatBubble({
                   fontSetting="n16m"
                   isLineBreak
                 />
-              ) : (
+              ) : opponentId !== 0 && id !== 0 && chatId !== 0 ? (
                 <ChatBubbleSelect
                   text="팀원초대 요청"
                   funcAccept={async () => {
@@ -141,6 +141,8 @@ export default function ChatBubble({
                   }}
                   isTeamInvite
                 />
+              ) : (
+                <ChatLoading />
               ),
               TEAM_INVITE_ACCEPTED: (
                 <Text

--- a/FE/components/molecules/ChatLoading/ChatLoading.stories.tsx
+++ b/FE/components/molecules/ChatLoading/ChatLoading.stories.tsx
@@ -9,6 +9,6 @@ export default {
 
 const Template: Story = () => <ChatLoading />;
 
-export const checkbox = Template.bind({});
+export const chatLoading = Template.bind({});
 
-checkbox.args = {};
+chatLoading.args = {};

--- a/FE/components/molecules/ChatLoading/ChatLoading.stories.tsx
+++ b/FE/components/molecules/ChatLoading/ChatLoading.stories.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Story } from '@storybook/react';
+import ChatLoading from './ChatLoading';
+
+export default {
+  title: 'Molecules/Chat Loading',
+  component: ChatLoading,
+};
+
+const Template: Story = () => <ChatLoading />;
+
+export const checkbox = Template.bind({});
+
+checkbox.args = {};

--- a/FE/components/molecules/ChatLoading/ChatLoading.tsx
+++ b/FE/components/molecules/ChatLoading/ChatLoading.tsx
@@ -2,6 +2,10 @@ import { ReactElement } from 'react';
 import styled from 'styled-components';
 
 const Wrapper = styled.div`
+  ${({ theme: { flexRow } }) => flexRow()}
+  width: 100%;
+  height: 20px;
+
   .typing__dot {
     float: left;
     width: 8px;

--- a/FE/components/molecules/ChatLoading/ChatLoading.tsx
+++ b/FE/components/molecules/ChatLoading/ChatLoading.tsx
@@ -1,0 +1,49 @@
+import { ReactElement } from 'react';
+import styled from 'styled-components';
+
+const Wrapper = styled.div`
+  .typing__dot {
+    float: left;
+    width: 8px;
+    height: 8px;
+    margin: 0 4px;
+    background: #8d8c91;
+    border-radius: 50%;
+    opacity: 0;
+    animation: loadingFade 1s infinite;
+  }
+
+  .typing__dot:nth-child(1) {
+    animation-delay: 0s;
+  }
+
+  .typing__dot:nth-child(2) {
+    animation-delay: 0.2s;
+  }
+
+  .typing__dot:nth-child(3) {
+    animation-delay: 0.4s;
+  }
+
+  @keyframes loadingFade {
+    0% {
+      opacity: 0;
+    }
+    50% {
+      opacity: 0.8;
+    }
+    100% {
+      opacity: 0;
+    }
+  }
+`;
+
+export default function ChatLoading(): ReactElement {
+  return (
+    <Wrapper>
+      <div className="typing__dot"></div>
+      <div className="typing__dot"></div>
+      <div className="typing__dot"></div>
+    </Wrapper>
+  );
+}

--- a/FE/components/molecules/ChatLoading/index.ts
+++ b/FE/components/molecules/ChatLoading/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ChatLoading';

--- a/FE/components/molecules/index.ts
+++ b/FE/components/molecules/index.ts
@@ -1,6 +1,7 @@
 import Button from './Button';
 import ChatBubble from './ChatBubble';
 import ChatBubbleSelect from './ChatBubbleSelect';
+import ChatLoading from './ChatLoading';
 import ChatInput from './ChatInput';
 import Checkbox from './Checkbox';
 import DropdownMenu from './DropdownMenu';
@@ -31,6 +32,7 @@ export {
   Button,
   ChatBubble,
   ChatBubbleSelect,
+  ChatLoading,
   ChatInput,
   Checkbox,
   DropdownMenu,

--- a/FE/components/organisms/ChatList/ChatList.tsx
+++ b/FE/components/organisms/ChatList/ChatList.tsx
@@ -9,10 +9,15 @@ interface UserList {
   room_name: string;
   last_chat_message: string;
   send_date_time: string;
-  unread_message_count: number | string;
+  unread_message_count: number;
 }
+
 interface ChatListProps {
-  handleToChatRoom: (id: number, room_name: string) => Promise<void>;
+  handleToChatRoom: (
+    id: number,
+    room_name: string,
+    unread_message_count: number,
+  ) => Promise<void>;
   handleGetChatLists: () => Promise<void>;
   userList: UserList[];
 }
@@ -70,7 +75,13 @@ export default function ChatList({
                 isActive={false}
                 time={send_date_time}
                 alertNumber={unread_message_count}
-                func={() => handleToChatRoom(chat_room_id, room_name)}
+                func={() =>
+                  handleToChatRoom(
+                    chat_room_id,
+                    room_name,
+                    unread_message_count,
+                  )
+                }
               />
             ),
           )

--- a/FE/components/organisms/ChatRoom/ChatRoom.tsx
+++ b/FE/components/organisms/ChatRoom/ChatRoom.tsx
@@ -5,7 +5,7 @@ import { Session } from 'openvidu-browser';
 
 import { ChatInput, ChatBubble } from '@molecules';
 
-import { postExitRoom, getRoomUserList } from '@repository/chatRepository';
+import { postExitRoom } from '@repository/chatRepository';
 import { Chat, ChatNormal } from '@types/chat-type';
 import { useAuthState } from '@store';
 
@@ -20,6 +20,7 @@ interface ChatRoomProps {
   handleClickSend: (msg: string) => Promise<void>;
   roomId?: number;
   opponentId?: number;
+  unreadMessageCount?: number;
 }
 
 const Wrapper = styled.div<{ disabled: boolean }>`
@@ -54,6 +55,7 @@ export default function ChatRoom({
   handleClickSend,
   roomId,
   opponentId,
+  unreadMessageCount,
 }: ChatRoomProps): ReactElement {
   const {
     user: { id },
@@ -64,7 +66,6 @@ export default function ChatRoom({
   const handleScrollToEnd = () => {
     chatBoxRef.current.scrollTo({
       top: chatBoxRef.current.scrollHeight - chatBoxRef.current.clientHeight,
-      left: 0,
     });
   };
 

--- a/FE/components/organisms/ChatRoom/ChatRoom.tsx
+++ b/FE/components/organisms/ChatRoom/ChatRoom.tsx
@@ -55,17 +55,24 @@ export default function ChatRoom({
   handleClickSend,
   roomId,
   opponentId,
-  unreadMessageCount,
+  unreadMessageCount = 0,
 }: ChatRoomProps): ReactElement {
   const {
     user: { id },
   } = useAuthState();
 
   const chatBoxRef: any = useRef<HTMLInputElement>(null);
+  const [unreadPosition, setUnreadPosition]: any = useState<HTMLInputElement>();
 
   const handleScrollToEnd = () => {
     chatBoxRef.current.scrollTo({
       top: chatBoxRef.current.scrollHeight - chatBoxRef.current.clientHeight,
+    });
+  };
+
+  const handleScrollToUnread = () => {
+    chatBoxRef.current.scrollTo({
+      top: unreadPosition.offsetTop,
     });
   };
 
@@ -80,12 +87,16 @@ export default function ChatRoom({
   };
 
   useEffect(() => {
+    if (unreadPosition) {
+      handleScrollToUnread();
+    }
+  }, [unreadPosition]);
+
+  useEffect(() => {
     return () => handleUnmount();
   }, [roomId]);
 
   useEffect(() => {
-    handleScrollToEnd();
-
     const interval = setInterval(() => {
       setMessageList([...messageList]);
     }, 60000);
@@ -128,47 +139,51 @@ export default function ChatRoom({
                 />
               ),
             )
-          : messageList
-              .slice(-30)
-              ?.map(
-                (
-                  {
-                    create_date_time,
-                    message,
-                    sender_id,
-                    sender_name,
-                    type,
-                    chat_id,
-                    team_id,
-                  }: ChatNormal,
-                  index: number,
-                ) => (
-                  <ChatBubble
-                    key={index}
-                    userName={sender_name}
-                    profileSrc="/profile.png"
-                    time={
-                      DateTime.now()
-                        .diff(DateTime.fromISO(create_date_time))
-                        .toMillis() < 60000
-                        ? '지금 막'
-                        : DateTime.fromISO(create_date_time)
-                            .setLocale('ko')
-                            .toRelative()
-                    }
-                    message={message}
-                    handleGetChatRoomMessages={handleGetChatRoomMessages}
-                    isMe={sender_id === id}
-                    func={sendMessage}
-                    type={type}
-                    roomId={roomId}
-                    opponentId={opponentId}
-                    chatId={chat_id}
-                    teamId={team_id}
-                    id={id}
-                  />
-                ),
-              )}
+          : messageList?.map(
+              (
+                {
+                  create_date_time,
+                  message,
+                  sender_id,
+                  sender_name,
+                  type,
+                  chat_id,
+                  team_id,
+                }: ChatNormal,
+                index: number,
+              ) => (
+                <ChatBubble
+                  key={index}
+                  userName={sender_name}
+                  profileSrc="/profile.png"
+                  time={
+                    DateTime.now()
+                      .diff(DateTime.fromISO(create_date_time))
+                      .toMillis() < 60000
+                      ? '지금 막'
+                      : DateTime.fromISO(create_date_time)
+                          .setLocale('ko')
+                          .toRelative()
+                  }
+                  message={message}
+                  handleGetChatRoomMessages={handleGetChatRoomMessages}
+                  isMe={sender_id === id}
+                  func={sendMessage}
+                  type={type}
+                  roomId={roomId}
+                  opponentId={opponentId}
+                  chatId={chat_id}
+                  teamId={team_id}
+                  id={id}
+                  ref={
+                    index === messageList.length - unreadMessageCount - 1
+                      ? setUnreadPosition
+                      : null
+                  }
+                  handleScrollToUnread={handleScrollToUnread}
+                />
+              ),
+            )}
       </div>
       <div className="chat-input">
         <ChatInput func={sendMessage} />

--- a/FE/components/organisms/ChatRoute/ChatRoute.tsx
+++ b/FE/components/organisms/ChatRoute/ChatRoute.tsx
@@ -172,7 +172,7 @@ export default function ChatRoute(): ReactElement {
       dispatch(setChatOpen({ isChatOpen: false }));
     }
 
-    if (!editRef?.current?.contains(target)) {
+    if (editRef.current && !editRef?.current?.contains(target)) {
       setIsEdit(false);
     }
   }

--- a/FE/components/organisms/ChatRoute/ChatRoute.tsx
+++ b/FE/components/organisms/ChatRoute/ChatRoute.tsx
@@ -21,12 +21,7 @@ import {
 import useSockStomp from '@hooks/useSockStomp';
 
 import { ChatList, ChatRoom, Modal } from '@organisms';
-import {
-  UserSelectChatAutoComplete,
-  Button,
-  DropdownMenu,
-  Tooltip,
-} from '@molecules';
+import { UserSelectChatAutoComplete, Button, DropdownMenu } from '@molecules';
 import { Text, Icon } from '@atoms';
 import { MODALS } from '@utils/constants';
 
@@ -147,6 +142,8 @@ export default function ChatRoute(): ReactElement {
 
   const [isEdit, setIsEdit] = useState(false);
 
+  const [unreadMessageCount, setUnreadMessageCount] = useState(0);
+
   const {
     handleSendMessage,
     handleSendRtcLink,
@@ -212,13 +209,22 @@ export default function ChatRoute(): ReactElement {
         const {
           data: { data },
         } = await getRoomUserList(room_id);
-        setOpponentId(data.filter(({ user_id }) => id !== user_id)[0].user_id);
+
+        setOpponentId(
+          data.filter(({ user_id }: { user_id: number }) => id !== user_id)[0]
+            .user_id,
+        );
       })();
     }
   }, [room_id]);
 
-  const handleToChatRoom = async (id: number, room_name: string) => {
+  const handleToChatRoom = async (
+    id: number,
+    room_name: string,
+    unread_message_count: number,
+  ) => {
     await setRoomId(id);
+    setUnreadMessageCount(unread_message_count);
     setRoomName(room_name);
     setRoute(CHAT_ROOM);
     const {
@@ -245,7 +251,7 @@ export default function ChatRoute(): ReactElement {
         if (route === CHAT_LIST) {
           const {
             data: {
-              data: { chat_room_id, room_name },
+              data: { chat_room_id, room_name, unread_message_count },
             },
           } = await postCreateRoom({
             userids: [
@@ -254,7 +260,7 @@ export default function ChatRoute(): ReactElement {
             ],
           });
 
-          handleToChatRoom(chat_room_id, room_name);
+          handleToChatRoom(chat_room_id, room_name, unread_message_count);
           return handleGetChatLists();
         }
 
@@ -464,6 +470,7 @@ export default function ChatRoute(): ReactElement {
                 handleClickSend={handleClickSend}
                 roomId={room_id}
                 opponentId={opponentId}
+                unreadMessageCount={unreadMessageCount}
               />
             ),
           }[route]

--- a/FE/components/organisms/ChatRoute/ChatRoute.tsx
+++ b/FE/components/organisms/ChatRoute/ChatRoute.tsx
@@ -463,6 +463,7 @@ export default function ChatRoute(): ReactElement {
                 setRoomId={setRoomId}
                 handleClickSend={handleClickSend}
                 roomId={room_id}
+                opponentId={opponentId}
               />
             ),
           }[route]


### PR DESCRIPTION
> resolve [#S05P13A202-248](https://jira.ssafy.com/browse/S05P13A202-248)

* ChatLoading 컴포넌트 구현 https://deploy-preview-256--determined-stonebraker-d1dfc9.netlify.app/?path=/story/molecules-chat-loading--chat-loading&utm_campaign=bot_dp&utm_source=github
* 메시지 type이 초대관련일 경우 post할 프로퍼티가 존재해야만 표시되도록 함(아니라면 ChatLoading 컴포넌트 표시)
* unreadMessageCount 와 setUnreadPosition 상태를 정의하여 안읽은 위치에서 스크롤을 멈추도록 처리�