### PR TITLE
유저별 세로비 export 추가 및 excel 코드 리팩토링

### DIFF
--- a/BE/teamgu/src/main/java/com/teamgu/api/dto/req/UserProjectExcelReqDto.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/dto/req/UserProjectExcelReqDto.java
@@ -1,0 +1,19 @@
+package com.teamgu.api.dto.req;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import io.swagger.annotations.ApiModel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ApiModel("유저를 특정 프로젝트에 추가 요청하는 객체")
+public class UserProjectExcelReqDto {
+	Long project_id;
+	MultipartFile file;
+}

--- a/BE/teamgu/src/main/java/com/teamgu/api/dto/res/VerticalByUserResDto.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/dto/res/VerticalByUserResDto.java
@@ -1,5 +1,24 @@
 package com.teamgu.api.dto.res;
 
-public class VerticalByUserResDto {
+import java.util.List;
 
+import io.swagger.annotations.ApiModel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ApiModel("유저별 세로비 정렬 응답 객체")
+public class VerticalByUserResDto {
+	String student_number;
+	String email;
+	String name;
+	String team_code;
+	String team_role;
+	String team_name;
+	String track_name;
 }

--- a/BE/teamgu/src/main/java/com/teamgu/api/service/ExcelService.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/service/ExcelService.java
@@ -1,0 +1,23 @@
+package com.teamgu.api.service;
+
+import java.io.IOException;
+import java.util.List;
+
+import com.teamgu.api.dto.req.TeamWithUserToExcelReqDto;
+import com.teamgu.api.dto.res.HorizontalByTeamResDto;
+import com.teamgu.api.dto.res.VerticalByUserResDto;
+
+public interface ExcelService {
+	/**
+	 * 팀별 가로비 Excel 파일을 생성하고 이를 base64 byte 형태로 반환한다 
+	 * @param teamWithUserToExcelReqDto
+	 * @return base64로 인코딩 된 byte[]
+	 */
+	public String createExcelToTeam(List<HorizontalByTeamResDto> horizontalByTeamResDto) throws IOException;
+	/**
+	 * 유저별 세로비 Excel 파일을 생성하고 이를 base64 byte 형태로 반환한다 
+	 * @param teamWithUserToExcelReqDto
+	 * @return base64로 인코딩 된 byte[]
+	 */
+	public String createExcelToUser(List<VerticalByUserResDto> verticalByUserResDto) throws IOException;
+}

--- a/BE/teamgu/src/main/java/com/teamgu/api/service/ExcelServiceImpl.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/service/ExcelServiceImpl.java
@@ -2,20 +2,31 @@ package com.teamgu.api.service;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Comparator;
 import java.util.List;
 
+import org.apache.commons.io.FilenameUtils;
+import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.xssf.streaming.SXSSFSheet;
 import org.apache.poi.xssf.streaming.SXSSFWorkbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import com.teamgu.api.dto.req.TeamWithUserToExcelReqDto;
+import com.teamgu.api.dto.res.ErrorResponse;
 import com.teamgu.api.dto.res.HorizontalByTeamResDto;
 import com.teamgu.api.dto.res.UserInfoByTeam;
 import com.teamgu.api.dto.res.VerticalByUserResDto;
+import com.teamgu.database.entity.User;
 
 import lombok.extern.log4j.Log4j2;
 
@@ -38,6 +49,12 @@ public class ExcelServiceImpl implements ExcelService{
 		
 		//시트 열 너비 설정
 //				sheet.setColumnWidth(columnIndex, width);
+
+		sheet.trackAllColumnsForAutoSizing();
+		for(int i = 0; i<=6;i++) {
+			sheet.autoSizeColumn(i);
+			sheet.setColumnWidth(i, (sheet.getColumnWidth(i))+(short)1024);
+		}
 		
 		//헤더 행 생성
 		Row headerRow = sheet.createRow(0);
@@ -120,6 +137,12 @@ public class ExcelServiceImpl implements ExcelService{
 		
 		//시트 열 너비 설정
 //						sheet.setColumnWidth(columnIndex, width);
+		
+		sheet.trackAllColumnsForAutoSizing();
+		for(int i = 0; i<=6;i++) {
+			sheet.autoSizeColumn(i);
+			sheet.setColumnWidth(i, (sheet.getColumnWidth(i))+(short)1024);
+		}
 		
 		//헤더 행 생성
 		Row headerRow = sheet.createRow(0);

--- a/BE/teamgu/src/main/java/com/teamgu/api/service/ExcelServiceImpl.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/service/ExcelServiceImpl.java
@@ -1,0 +1,183 @@
+package com.teamgu.api.service;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Base64;
+import java.util.Comparator;
+import java.util.List;
+
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.xssf.streaming.SXSSFSheet;
+import org.apache.poi.xssf.streaming.SXSSFWorkbook;
+import org.springframework.stereotype.Service;
+
+import com.teamgu.api.dto.req.TeamWithUserToExcelReqDto;
+import com.teamgu.api.dto.res.HorizontalByTeamResDto;
+import com.teamgu.api.dto.res.UserInfoByTeam;
+import com.teamgu.api.dto.res.VerticalByUserResDto;
+
+import lombok.extern.log4j.Log4j2;
+
+@Log4j2
+@Service("ExcelService")
+public class ExcelServiceImpl implements ExcelService{
+	@Override
+	public String createExcelToTeam(List<HorizontalByTeamResDto> horizontalList) throws IOException {
+		//2. 컬럼 갯수를 파악하기 위해 최대 인원 구성 수를 파악한다
+		int maxMembers = 0;
+		for(int i =0;i<horizontalList.size();i++) {
+			maxMembers = Integer.max(horizontalList.get(i).getMembers().size(),maxMembers);			
+		}
+		
+		//3. 엑셀 파일의 초기 설정을 한다
+		SXSSFWorkbook workbook = new SXSSFWorkbook();
+		
+		//시트생성
+		SXSSFSheet sheet = workbook.createSheet("팀별 가로비");
+		
+		//시트 열 너비 설정
+//				sheet.setColumnWidth(columnIndex, width);
+		
+		//헤더 행 생성
+		Row headerRow = sheet.createRow(0);
+		//해당 행의 열 셀 생성
+		Cell headerCell =null;
+		
+		//공통 정보에 대한 헤더 생성
+		String[] headers = {"기수","프로젝트","트랙","팀명"};
+		for(int i=0;i<headers.length;i++) {
+			headerCell = headerRow.createCell(i);
+			headerCell.setCellValue(headers[i]);			
+		}
+		//멤버 정보에 대한 헤더 생성
+		headerCell = headerRow.createCell(headers.length);
+		headerCell.setCellValue("팀장");
+		for(int i =headers.length+1;i<headers.length+maxMembers;i++) {			
+			headerCell = headerRow.createCell(i);
+			headerCell.setCellValue("팀원"+(i-headers.length));//팀원1, 팀원2 ,,,,
+		}
+		
+		//4. 내용 행 및 셀 생성
+		Row bodyRow = null;
+		Cell bodyCell = null;
+		for(int i =0;i<horizontalList.size();i++) {
+			HorizontalByTeamResDto info = horizontalList.get(i);
+			
+			//행 생성
+			bodyRow = sheet.createRow(i+1);//header 다음 줄부터
+			
+			//데이터 기수 표시
+			bodyCell = bodyRow.createCell(0);
+			bodyCell.setCellValue(info.getStage_name());
+			
+			//데이터 프로젝트 도메인 표시
+			bodyCell = bodyRow.createCell(1);
+			bodyCell.setCellValue(info.getProject_name());
+			
+			//데이터 트랙 표시
+			bodyCell = bodyRow.createCell(2);
+			bodyCell.setCellValue(info.getTrack_name());
+			
+			//데이터 팀명 표시
+			bodyCell = bodyRow.createCell(3);
+			bodyCell.setCellValue(info.getName());
+			
+			//데이터 멤버 표시
+			//우선 팀장을 가장 위로 정렬해준다(셀 맨 앞이 팀장이므로)
+			info.getMembers().sort(new Comparator<UserInfoByTeam>() {
+				@Override
+				public int compare(UserInfoByTeam o1, UserInfoByTeam o2) {					
+					if(o1.getRole().equals("팀장"))
+						return -1;
+					else return 0;
+				}
+			});
+			for(int j=0;j<info.getMembers().size();j++) {
+				UserInfoByTeam userInfo = info.getMembers().get(j); 
+				bodyCell = bodyRow.createCell(j+4);
+				//이름(학번) 형태로 기재
+				bodyCell.setCellValue(userInfo.getName()+"("+userInfo.getStudentNumber()+")");				
+			}
+		}
+		ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+		log.info("wirte stream");
+		workbook.write(outputStream);
+		
+		//base64 인코딩
+		String bres = Base64.getEncoder().encodeToString(outputStream.toByteArray());
+		workbook.close();				
+		return bres;
+	}
+	@Override
+	public String createExcelToUser(List<VerticalByUserResDto> verticalList) throws IOException {
+		
+		//3. 엑셀 파일의 초기 설정을 한다
+		SXSSFWorkbook workbook = new SXSSFWorkbook();
+		
+		//시트생성
+		SXSSFSheet sheet = workbook.createSheet("유저별 세로비");
+		
+		//시트 열 너비 설정
+//						sheet.setColumnWidth(columnIndex, width);
+		
+		//헤더 행 생성
+		Row headerRow = sheet.createRow(0);
+		//해당 행의 열 셀 생성
+		Cell headerCell =null;
+		
+		//공통 정보에 대한 헤더 생성
+		String[] headers = {"학번","이름","이메일","팀코드","팀명","역할","트랙"};
+		for(int i=0;i<headers.length;i++) {
+			headerCell = headerRow.createCell(i);
+			headerCell.setCellValue(headers[i]);			
+		}
+		
+		//4. 내용 행 및 셀 생성
+		Row bodyRow = null;
+		Cell bodyCell = null;
+		for(int i =0;i<verticalList.size();i++) {
+			VerticalByUserResDto info = verticalList.get(i);
+			
+			//행 생성
+			bodyRow = sheet.createRow(i+1);//header 다음 줄부터
+			
+			//데이터 학번 표시
+			bodyCell = bodyRow.createCell(0);
+			bodyCell.setCellValue(info.getStudent_number());
+			
+			//데이터 이름 표시
+			bodyCell = bodyRow.createCell(1);
+			bodyCell.setCellValue(info.getName());
+			
+			//데이터 이메일 표시
+			bodyCell = bodyRow.createCell(2);
+			bodyCell.setCellValue(info.getEmail());
+			
+			//데이터 팀코드 표시
+			bodyCell = bodyRow.createCell(3);
+			bodyCell.setCellValue(info.getTeam_code());
+			
+			//데이터 팀명 표시
+			bodyCell = bodyRow.createCell(4);
+			bodyCell.setCellValue(info.getTeam_name());
+			
+			//데이터 역할 표시
+			bodyCell = bodyRow.createCell(5);
+			bodyCell.setCellValue(info.getTeam_role());
+			
+			//데이터 트랙 표시
+			bodyCell = bodyRow.createCell(6);
+			bodyCell.setCellValue(info.getTrack_name());
+			
+		}
+		ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+		log.info("wirte stream");
+		workbook.write(outputStream);
+		
+		//base64 인코딩
+		String bres = Base64.getEncoder().encodeToString(outputStream.toByteArray());
+		workbook.close();				
+		return bres;
+	}
+}

--- a/BE/teamgu/src/main/java/com/teamgu/api/service/TeamService.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/service/TeamService.java
@@ -7,6 +7,7 @@ import com.teamgu.api.dto.req.TeamMemberReqDto;
 import com.teamgu.api.dto.req.TeamAutoCorrectReqDto;
 import com.teamgu.api.dto.res.TeamIsCreateResDto;
 import com.teamgu.api.dto.res.TeamListResDto;
+import com.teamgu.api.dto.res.VerticalByUserResDto;
 import com.teamgu.api.dto.res.HorizontalByTeamResDto;
 import com.teamgu.api.dto.res.TeamAutoCorrectResDto;
 
@@ -73,4 +74,14 @@ public interface TeamService {
 	 * @return
 	 */
 	List<HorizontalByTeamResDto> getHorizontalByTeamInfo(int project_code, int stage_code);
+	
+	/**
+	 * 특정 기수, 프로젝트 도메인 코드를 입력하면
+	 * 해당 조건에 맞는 모든 유저와 해당 유저가 속한 팀의 정보를
+	 * 엑셀 데이터 출력에 맞게 반환한다.
+	 * @param project_code
+	 * @param stage_code
+	 * @return
+	 */
+	List<VerticalByUserResDto> getVerticalByUserInfo(int project_code,int stage_code);
 }

--- a/BE/teamgu/src/main/java/com/teamgu/api/service/TeamServiceImpl.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/service/TeamServiceImpl.java
@@ -17,6 +17,7 @@ import com.teamgu.api.dto.res.TeamAutoCorrectResDto;
 import com.teamgu.api.dto.res.TeamIsCreateResDto;
 import com.teamgu.api.dto.res.TeamListResDto;
 import com.teamgu.api.dto.res.TeamMemberInfoResDto;
+import com.teamgu.api.dto.res.VerticalByUserResDto;
 import com.teamgu.database.entity.Mapping;
 import com.teamgu.database.entity.Team;
 import com.teamgu.database.entity.User;
@@ -398,5 +399,10 @@ public class TeamServiceImpl implements TeamService {
 	@Override
 	public List<HorizontalByTeamResDto> getHorizontalByTeamInfo(int project_code, int stage_code) {
 		return teamRepositorySupport.getUserListByTeam(teamRepositorySupport.getTeamList(project_code, stage_code));
+	}
+	
+	@Override
+	public List<VerticalByUserResDto> getVerticalByUserInfo(int project_code, int stage_code) {
+		return teamRepositorySupport.getUserListByTeamVertical(stage_code, project_code);
 	}
 }


### PR DESCRIPTION
## 유저별 세로비 export 기능 추가
![image](https://user-images.githubusercontent.com/47562093/129544491-e64b74f3-8163-42ab-8c5e-a229ed19a2bd.png)

- 유저별 세로비 export 기능이 추가되었습니다.
      - 가로비와 마찬가지로 project_code와 stage_code 값이 필요합니다.
- 가로비와 세로비 export에 대한 URI가 변경되었습니다. @minho-jang 
      - `/user/excel` 유저별 세로비
      - `/team/excel` 팀별 가로비
       
## Excel 코드 리팩토링
- 기존 모든 비즈니스 로직이 Controller에서 수행되었으나 이를 Service로 분리하여 리팩토링 했습니다.
