### PR TITLE
feat: 교육생 관리 정보 수정 추가, 프로젝트에서 제외 기능 리팩토링, DTO 수정

### DIFF
--- a/BE/teamgu/src/main/java/com/teamgu/api/controller/AdminController.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/controller/AdminController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.teamgu.api.dto.req.AdminManagementReqDto;
+import com.teamgu.api.dto.req.AdminUserManagementReqDto;
 import com.teamgu.api.dto.req.AdminUserProjectManagementReqDto;
 import com.teamgu.api.dto.req.ProjectCodeReqDto;
 import com.teamgu.api.dto.req.StdClassReqDto;
@@ -26,7 +27,7 @@ import com.teamgu.api.dto.res.BasicResponse;
 import com.teamgu.api.dto.res.CodeResDto;
 import com.teamgu.api.dto.res.CommonResponse;
 import com.teamgu.api.dto.res.DashBoardResDto;
-import com.teamgu.api.dto.res.DashBoardTableResDto;
+import com.teamgu.api.dto.res.AdminUserProjectManagementResDto;
 import com.teamgu.api.dto.res.ErrorResponse;
 import com.teamgu.api.dto.res.ProjectInfoResDto;
 import com.teamgu.api.service.AdminServiceImpl;
@@ -170,13 +171,13 @@ public class AdminController {
 	
 	@ApiOperation(value = "Project에 참여중인 교육생 조회")
 	@GetMapping("/project/{projectId}")
-	public ResponseEntity<? extends BasicResponse> getTeamBuildingTable(@PathVariable Long projectId) {
+	public ResponseEntity<? extends BasicResponse> getUserInProjectManagementData(@PathVariable Long projectId) {
 
 		if(adminService.checkProjectValidation(projectId)) { // 존재하는 프로젝트일 경우
 
-			List<DashBoardTableResDto> dashBoardTable = adminService.getDashBoardTableInfo(projectId);
+			List<AdminUserProjectManagementResDto> userListInProject = adminService.getUserInProjectManagementData(projectId);
 			
-			return ResponseEntity.ok(new CommonResponse<List<DashBoardTableResDto>>(dashBoardTable));
+			return ResponseEntity.ok(new CommonResponse<List<AdminUserProjectManagementResDto>>(userListInProject));
 		}
 		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
 				.body(new ErrorResponse("존재하지 않는 프로젝트입니다"));
@@ -210,8 +211,8 @@ public class AdminController {
 		
 		if(adminService.checkProjectValidation(projectId)) { // 존재하는 프로젝트일 경우
 			
-			List<AdminUserManagementResDto> list = adminService.getUserManagamentData(projectId, regionCode);
-			return ResponseEntity.ok(new CommonResponse<List<AdminUserManagementResDto>>(list));
+			List<AdminUserManagementResDto> userList = adminService.getUserManagamentData(projectId, regionCode);
+			return ResponseEntity.ok(new CommonResponse<List<AdminUserManagementResDto>>(userList));
 
 		}
 		
@@ -309,6 +310,24 @@ public class AdminController {
 				.body(new ErrorResponse("삭제할 수 없는 항목입니다. 데이터를 확인하기 바랍니다.")); 
 		
 	}
+	
+	@ApiOperation(value = "Student Information 수정")
+	@PutMapping("/user/{userId}")
+	public ResponseEntity<? extends BasicResponse> updateStudentInformation(@RequestBody AdminUserManagementReqDto adminUserManagementReqDto){
+		
+		try {
+			adminService.updateStudentInformation(adminUserManagementReqDto);
+			
+		} catch (Exception e) {
+			e.printStackTrace();
+			return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+					.body(new ErrorResponse("수정 중 오류가 발생하였습니다")); 
+		} finally {
+			return ResponseEntity.status(HttpStatus.OK)
+					.body(new CommonResponse<String>("수정이 완료 되었습니다"));
+		}
+		
+	}
 
 	@ApiOperation(value = "Project에 Student 추가")
 	@PostMapping("/project/add")
@@ -320,9 +339,9 @@ public class AdminController {
 		if(adminService.checkUserProjectDetail(userId, projectId)) { // User가 이 프로젝트에 존재하지 않으면
 			adminService.addStudentToProject(userId, projectId);
 			
-			List<DashBoardTableResDto> dashBoardTable = adminService.getDashBoardTableInfo(projectId);
+			List<AdminUserProjectManagementResDto> userListInProject = adminService.getUserInProjectManagementData(projectId);
 			
-			return ResponseEntity.ok(new CommonResponse<List<DashBoardTableResDto>>(dashBoardTable));
+			return ResponseEntity.ok(new CommonResponse<List<AdminUserProjectManagementResDto>>(userListInProject));
 			
 		}
 		
@@ -330,7 +349,6 @@ public class AdminController {
 				.body(new ErrorResponse("이미 프로젝트에 존재하는 교육생입니다")); 
 		
 	}
-	
 
 	@ApiOperation(value = "Project에 Student 제외")
 	@PostMapping("/project/exclude")
@@ -339,54 +357,10 @@ public class AdminController {
 		Long userId = adminUserProjectManagementReqDto.getUserId();
 		Long projectId = adminUserProjectManagementReqDto.getProjectId();
 		
-		AdminTeamManagementResDto team = adminService.getStudentProjectTeamInfo(userId, projectId);
-		
-		if(team == null) {
-			adminService.excludeStudentFromProject(userId, projectId);
-			return ResponseEntity.ok(new CommonResponse<String>("프로젝트에서 제외가 완료되었습니다"));
-		}
-		else {
-			
-			Long teamId = team.getTeamId();
-			Long leaderId = team.getLeaderId();
-		
-			List<Long> ids = teamService.getTeamMemberIdbyTeamId(teamId);
-			int teamMebmerCount = ids.size();
+		String result = adminService.excludeStudentFromProject(userId, projectId);
 
-			adminService.excludeStudentFromProject(userId, projectId);
-			
-			if(teamMebmerCount == 1) {
-				teamService.deleteTeam(teamId);
-				
-				return ResponseEntity.ok(new CommonResponse<String>("팀을 삭제하고 프로젝트에서 제외가 완료되었습니다"));
-
-			}else {
-				for(Long id : ids) {
-					if(id == leaderId) continue;
-					
-					TeamMemberReqDto newLeader = TeamMemberReqDto.builder()
-							.teamId(teamId)
-							.userId(id)
-							.build()
-							;
-					TeamMemberReqDto exitTeam = TeamMemberReqDto.builder()
-							.teamId(teamId)
-							.userId(userId)
-							.build();
-					
-					teamService.changeTeamLeader(newLeader);
-					teamService.exitTeam(exitTeam);
-					
-					return ResponseEntity.ok(new CommonResponse<String>("팀에서 탈퇴하고 프로젝트에서 제외가 완료되었습니다"));
-					
-				}
-				
-			}
-		}
-		
-		return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-				.body(new ErrorResponse("이미 프로젝트에 존재하지 않는 교육생입니다")); 
-		
+		return ResponseEntity.status(HttpStatus.OK)
+				.body(new CommonResponse<String>(result));
 	}
 	
 }

--- a/BE/teamgu/src/main/java/com/teamgu/api/dto/req/AdminUserManagementReqDto.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/dto/req/AdminUserManagementReqDto.java
@@ -1,0 +1,26 @@
+package com.teamgu.api.dto.req;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+
+@Getter
+@ApiModel(description = "Student Information Update Request Model")
+public class AdminUserManagementReqDto {
+	
+	@ApiModelProperty(name = "교육생 ID", example = "1")
+	Long userId;
+	
+	@ApiModelProperty(name = "프로젝트 ID", example = "1")
+	Long projectId;
+	
+	@ApiModelProperty(name = "교육생 반", example = "1")	
+	Long classId;
+	
+	@ApiModelProperty(name = "교육생 전공", example = "1")
+	short major;
+	
+	@ApiModelProperty(name = "교육생 / 퇴소생", example = "1")
+	short role;
+
+}

--- a/BE/teamgu/src/main/java/com/teamgu/api/dto/res/AdminUserManagementResDto.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/dto/res/AdminUserManagementResDto.java
@@ -14,11 +14,17 @@ import lombok.NoArgsConstructor;
 @ApiModel(description = "Admin User Status Response Model")
 public class AdminUserManagementResDto {
 
+	@ApiModelProperty(name = "교육생 ID", example = "")
+	Long userId;
+	
 	@ApiModelProperty(name = "학번", example = "0540000")
 	String studentNumber;
 
 	@ApiModelProperty(name = "이름", example = "김싸피")
 	String name;
+
+	@ApiModelProperty(name = "교육생 이메일", example = "ssafy@ssafy.com")
+	String email;
 
 	@ApiModelProperty(name = "지역", example = "서울")
 	String region;

--- a/BE/teamgu/src/main/java/com/teamgu/api/dto/res/AdminUserProjectManagementResDto.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/dto/res/AdminUserProjectManagementResDto.java
@@ -12,8 +12,11 @@ import lombok.Setter;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@ApiModel(description = "Dash Board Table Response Model")
-public class DashBoardTableResDto {
+@ApiModel(description = "Studnet Information In project")
+public class AdminUserProjectManagementResDto {
+	
+	@ApiModelProperty(name = "교육생 고유 ID", example = "1")
+	Long userId;
 
 	@ApiModelProperty(name = "학번", example = "0510000")
 	String studentNumber;

--- a/BE/teamgu/src/main/java/com/teamgu/api/service/AdminService.java
+++ b/BE/teamgu/src/main/java/com/teamgu/api/service/AdminService.java
@@ -2,11 +2,13 @@ package com.teamgu.api.service;
 
 import java.util.List;
 
+import com.teamgu.api.dto.req.AdminUserManagementReqDto;
+import com.teamgu.api.dto.req.AdminUserProjectManagementReqDto;
 import com.teamgu.api.dto.res.AdminTeamManagementResDto;
 import com.teamgu.api.dto.res.AdminUserManagementResDto;
 import com.teamgu.api.dto.res.CodeResDto;
 import com.teamgu.api.dto.res.DashBoardResDto;
-import com.teamgu.api.dto.res.DashBoardTableResDto;
+import com.teamgu.api.dto.res.AdminUserProjectManagementResDto;
 import com.teamgu.api.dto.res.ProjectInfoResDto;
 
 public interface AdminService {
@@ -122,12 +124,12 @@ public interface AdminService {
 	public DashBoardResDto getTeamBuildingStatus(Long projectId);
 
 	/**
-	 * Select Dashboard Table Data
-	 * Project Id를 통해 Dash Board 하단 테이블 데이터를 조회한다
+	 * Select User Information In Project to manage
+	 * Project Id를 통해 프로젝트별 참여중인 교육생을 조회한다.
 	 * @param projectId
 	 * @return
 	 */
-	public List<DashBoardTableResDto> getDashBoardTableInfo(Long projectId);
+	public List<AdminUserProjectManagementResDto> getUserInProjectManagementData(Long projectId);
 	
 	
 	/**
@@ -228,7 +230,7 @@ public interface AdminService {
 	 * @param userId
 	 * @param projectId
 	 */
-	public void excludeStudentFromProject(Long userId, Long projectId);
+	public String excludeStudentFromProject(Long userId, Long projectId);
 
 	/**
 	 * get Team Information student belongs to
@@ -239,4 +241,11 @@ public interface AdminService {
 	 */
 	public AdminTeamManagementResDto getStudentProjectTeamInfo(Long userId, Long projectId);
 	
+	//
+	/**
+	 * Update Student Information
+	 * 교육생의 반, 전공/비전공, 퇴소 여부를 수정한다.
+	 * @param adminUserProjectManagementReqDto
+	 */
+	public void updateStudentInformation(AdminUserManagementReqDto adminUserManagementReqDto);
 }


### PR DESCRIPTION
* 관리자의 교육생 반 / 전공 / 퇴소여부 정보 `수정` 기능 추가 
  * 기존 반과 변경 반이 다를 경우 기존 반을 삭제하고 변경된 반을 추가
  * 퇴소처리 될 경우 퇴소 처리된 시점의 프로젝트를 제외 => 추후 의논후 전체 프로젝트를 날려야 한다면 추가 예정
* Controller에서 이루어지던 교육생의 프로젝트 제외 기능을 Service로 이동
* 전체 교육생 관리 / 프로젝트별 교육생 관리에 교육생 고유 번호 및 이메일 추가로 DTO 수정