### PR TITLE
팀 나가기 이후에도 나의 팀이 사라지지 않는 버그 수정

### DIFF
--- a/FE/components/organisms/TeamStatus/TeamStatus.tsx
+++ b/FE/components/organisms/TeamStatus/TeamStatus.tsx
@@ -87,10 +87,6 @@ export default function TeamStatus(): ReactElement {
       studentNumber,
     });
 
-    const project =
-      projectCodes && projectCodes.length > 0
-        ? projectCodes[projectCodes.length - 1]
-        : 101;
     getUserHasTeam({
       userId,
       project: { code: projectCode },
@@ -139,6 +135,13 @@ export default function TeamStatus(): ReactElement {
 
     getTeamsFiltered(payloadTemp).then(({ data: { data } }) => {
       setTeams(data);
+    });
+    getUserHasTeam({
+      userId,
+      project: { code: projectCode },
+    }).then(({ data: { data } }) => {
+      setUserHasTeam(data.hasTeam);
+      setUserTeam(data.team);
     });
   };
 


### PR DESCRIPTION
팀 정보를 리렌더링 할 때마다, 현재 사용자가 팀이 있는지 확인하는 방식으로 수정