### PR TITLE
로그아웃시 토큰의 기능을 삭제하는 api 통신을 추가합니다

### DIFF
--- a/FE/components/organisms/ProtectedRoute/ProtectedRoute.tsx
+++ b/FE/components/organisms/ProtectedRoute/ProtectedRoute.tsx
@@ -16,7 +16,6 @@ export default function ProtectedRoute({ children }: ProtectedRouteProps) {
 
   useEffect(() => {
     const accessToken = loadItem('accessToken');
-
     if (accessToken && !user.name) {
       (async () => {
         try {
@@ -38,7 +37,7 @@ export default function ProtectedRoute({ children }: ProtectedRouteProps) {
       setFlag(true);
       router.push('/');
     }
-  }, []);
+  }, [router.pathname]);
 
   useEffect(() => {
     const start = () => {

--- a/FE/repository/baseRepository.ts
+++ b/FE/repository/baseRepository.ts
@@ -7,6 +7,12 @@ export const postLoginApi = async (param: object) =>
     param,
   });
 
+export const getLogout = async () =>
+  await api({
+    url: '/api/auth/logout',
+    type: 'get',
+  });
+
 export const getUserInfo = async () =>
   await api({
     url: `/api/v1/users/me`,

--- a/FE/store/authSlice.ts
+++ b/FE/store/authSlice.ts
@@ -129,8 +129,6 @@ export const setLogout =
 
     await getLogout();
     removeItem('accessToken');
-    removeItem('refreshToken');
 
     router.push('/');
-    router.reload();
   };

--- a/FE/store/authSlice.ts
+++ b/FE/store/authSlice.ts
@@ -1,5 +1,9 @@
 import { createSlice } from '@reduxjs/toolkit';
-import { postLoginApi, getUserInfo } from '@repository/baseRepository';
+import {
+  postLoginApi,
+  getUserInfo,
+  getLogout,
+} from '@repository/baseRepository';
 import { AppDispatch } from '@store';
 import { NextRouter } from 'next/router';
 import { saveItem, removeItem } from '@utils/storage';
@@ -96,7 +100,6 @@ export const setLogin =
           ? router.push('/userdetail')
           : router.push('/humanpool');
       }
-      
     } catch (error) {
       console.error(error);
       return error.response;
@@ -120,11 +123,14 @@ export const setUserInfo = () => async (dispatch: AppDispatch) => {
   }
 };
 
-export const setLogout = (router: NextRouter) => (dispatch: AppDispatch) => {
-  dispatch(setUser(initialState));
-  removeItem('accessToken');
-  removeItem('refreshToken');
+export const setLogout =
+  (router: NextRouter) => async (dispatch: AppDispatch) => {
+    dispatch(setUser(initialState));
 
-  router.push('/');
-  location.reload();
-};
+    await getLogout();
+    removeItem('accessToken');
+    removeItem('refreshToken');
+
+    router.push('/');
+    router.reload();
+  };


### PR DESCRIPTION
로그아웃시 토큰의 기능을 삭제하는 api 통신을 추가합니다

[778cca3](https://github.com/team-gu/service/pull/282/commits/778cca32aba2a5e4de40e178f370dc3467ba78dd) 
가장 큰 문제가 ProtectedRoute 부분이 첫렌더링시에만 작동한다는 것입니다. 정확하게는 모르겠으나 지금 추측되는 걸로는 next.js의 특성 때문이지 않을까 싶습니다. (SSR + CSR)
기존 코드의 경우에서는 해당 페이지에 첫 접속을 하고 로그아웃을 눌렀을 경우에만 제대로 동작하였습니다. (해당 경우에만 ProtectedRoute의 첫번째 useEffect가 작동하기 때문) 이미 방문되었던 페이지를 재방문 후 로그아웃하게 되면 하단에 null이 반환되는 로직이 작동되어 홈화면으로 가지 못하였습니다.

때문에 deps 배열에 router.pathname을 넣어서 url이 바뀔 때마다 해당 useEffect가 작동하도록 강제하였습니다. 이 덕분에 이미 방문하였던 페이지를 재방문 후 로그아웃 하여도 제대로 메인 페이지로 가지만 url이 바뀌지 않는 경우 즉, 마이페이지에서 마이페이지 수정으로 가는 경우 등에서는 똑같이 useEffect가 동작하지 않아 메인화면으로 가지지 않습니다.

아예 deps 배열을 없애거나 children을 넣게 되면 useEffect가 멈추지 않고 계속 반복되기 때문에 어떻게 안쪽 컴포넌트가 바뀔 때마다 useEffect가 실행되도록할 지에 대한 고민이 필요한 부분인 것 같습니다. 일단 이렇게만 두어도 대부분의 경우에서 제대로 동작하기 때문에 이런 식으로 수정해 두겠습니다.