### PR TITLE
강제로 막았던 이미지 캐시를 풉니다

### DIFF
--- a/FE/utils/constants.ts
+++ b/FE/utils/constants.ts
@@ -44,7 +44,7 @@ export const CODE_ID = {
 };
 
 export const getImageURL = (image: string) => {
-  if (image) return `${image}#` + new Date().getTime();
+  if (image) return image;
   return 'https://i5a202.p.ssafy.io:8080/api/file/display?url=profile/c21f969b5f03d33d43e04f8f136e7682.png';
 };
 


### PR DESCRIPTION
기존에는 프로필 이미지가 등록된 상태에서 새롭게 프로필 이미지를 등록하게 되면 이미지의 url이 같아 변화가 반영되지 못하였습니다. 하지만, 백엔드에서 이미지의 url을 다르게 관리해주시겠다고 하여 뒤에 new Date()를 붙여서 이미지 캐싱을 막았던 것을 풀겠습니다.